### PR TITLE
Bug: /_etag/? not auto-added to ExcludedPaths on container creation

### DIFF
--- a/tests/CosmosDB.InMemoryEmulator.Tests/EtagExcludedPathsBugReproduction.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests/EtagExcludedPathsBugReproduction.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+using Microsoft.Azure.Cosmos;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Bug: /_etag/? not auto-added to IndexingPolicy.ExcludedPaths on container creation.
+///
+/// Found while migrating ASOS/SimpleEventStore to use InMemoryEmulator.
+/// See: https://github.com/McNultyyy/SimpleEventStore/tree/use-inmemory-emulator
+///
+/// Real Cosmos DB automatically adds "/_etag/?" to ExcludedPaths whenever a container
+/// is created with a custom IndexingPolicy. The InMemoryEmulator does not do this,
+/// causing tests that assert on ExcludedPaths.Count to fail.
+/// </summary>
+public class EtagExcludedPathsBugReproduction
+{
+    [Fact]
+    public async Task ContainerProperties_ShouldAutoAddEtagToExcludedPaths()
+    {
+        var client = new InMemoryCosmosClient();
+        var database = (await client.CreateDatabaseIfNotExistsAsync("etag-index-db")).Database;
+
+        var containerProperties = new ContainerProperties("test-container", "/partitionKey")
+        {
+            IndexingPolicy = new IndexingPolicy
+            {
+                ExcludedPaths = { new ExcludedPath { Path = "/body/*" }, new ExcludedPath { Path = "/metaData/*" } }
+            }
+        };
+        await database.CreateContainerIfNotExistsAsync(containerProperties);
+
+        var container = database.GetContainer("test-container");
+        var response = await container.ReadContainerAsync();
+        var excludedPaths = response.Resource.IndexingPolicy.ExcludedPaths.Select(p => p.Path).ToList();
+
+        // Real Cosmos auto-adds /_etag/? to excluded paths
+        excludedPaths.Should().Contain("/_etag/?",
+            "Cosmos DB auto-adds /_etag/? to ExcludedPaths when a custom IndexingPolicy is provided");
+    }
+}


### PR DESCRIPTION
## Summary

Real Cosmos DB automatically adds `/_etag/?` to `IndexingPolicy.ExcludedPaths` when a container is created with a custom IndexingPolicy. InMemoryEmulator does not.

## Found in

[ASOS/SimpleEventStore](https://github.com/ASOS/SimpleEventStore) — test `when_initializing_all_expected_resources_are_created` asserts `ExcludedPaths.Count == 3` (2 user-defined + the auto-added `/_etag/?`). Fails because InMemoryEmulator only returns the 2 user-defined paths.

## Reproduction

Fork with full migration: https://github.com/McNultyyy/SimpleEventStore/tree/use-inmemory-emulator

## Test plan

- [ ] Run the failing test in this PR: `EtagExcludedPathsBugReproduction.ContainerProperties_ShouldAutoAddEtagToExcludedPaths`

🤖 Generated with [Claude Code](https://claude.com/claude-code)