### PR TITLE
fix: mark GitHub Releases as prerelease for pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,14 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == *-* ]]; then
+            echo "PRERELEASE=true" >> $GITHUB_OUTPUT
+          else
+            echo "PRERELEASE=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build
         run: dotnet build CosmosDB.InMemoryEmulator.sln --configuration Release -p:Version=${{ steps.version.outputs.VERSION }}
@@ -59,4 +66,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.version.outputs.PRERELEASE == 'true' }}
+          make_latest: ${{ steps.version.outputs.PRERELEASE != 'true' }}
           files: ./nupkgs/*.nupkg


### PR DESCRIPTION
## Problem

Tags with semver prerelease suffixes (e.g. `v2.0.184-beta.1`) were being published as full GitHub Releases because `softprops/action-gh-release` doesn't auto-detect prerelease tags.

## Fix

- The version extraction step now checks for a `-` in the version (the semver prerelease delimiter) and sets a `PRERELEASE` output flag
- The GitHub Release step uses `prerelease:` to mark the release accordingly
- `make_latest:` is set to `false` for prereleases so they don't replace the latest stable release

Any tag like `v2.0.185-beta.1`, `v3.0.0-rc.1`, or `v1.0.0-alpha` will now be marked as a prerelease. Clean tags like `v2.0.185` continue to be full releases.