### PR TITLE
chore: CI improvements, parity report enhancements, and AGENTS.md policies

### DIFF
--- a/.github/workflows/emulator-parity.yml
+++ b/.github/workflows/emulator-parity.yml
@@ -18,7 +18,7 @@ permissions:
 # workflow still completes without infra failures (partition exhaustion,
 # connection-refused storms, timeouts) before adding the next.
 env:
-  PARITY_FILTER: ${{ inputs.filter || 'FullyQualifiedName~FakeCosmosHandlerCrudTests|FullyQualifiedName~FakeCosmosHandlerTtlTests|FullyQualifiedName~FakeCosmosHandlerBatchTests|FullyQualifiedName~FakeCosmosHandlerQueryAdvancedTests|FullyQualifiedName~Issue18ExceptionTypeTests|FullyQualifiedName~Issue18EdgeCaseIntegrationTests' }}
+  PARITY_FILTER: ${{ inputs.filter || 'FullyQualifiedName~FakeCosmosHandlerCrudTests|FullyQualifiedName~FakeCosmosHandlerTtlTests|FullyQualifiedName~FakeCosmosHandlerBatchTests|FullyQualifiedName~FakeCosmosHandlerQueryAdvancedTests' }}
   # Note: Linux emulator job is commented out below. See #51 for details:
   #   https://github.com/lemonlion/CosmosDB.InMemoryEmulator/issues/51
 

--- a/.github/workflows/emulator-parity.yml
+++ b/.github/workflows/emulator-parity.yml
@@ -18,13 +18,9 @@ permissions:
 # workflow still completes without infra failures (partition exhaustion,
 # connection-refused storms, timeouts) before adding the next.
 env:
-  PARITY_FILTER: ${{ inputs.filter || 'FullyQualifiedName~FakeCosmosHandlerCrudTests|FullyQualifiedName~FakeCosmosHandlerTtlTests|FullyQualifiedName~FakeCosmosHandlerBatchTests|FullyQualifiedName~FakeCosmosHandlerQueryAdvancedTests' }}
-  # Excluded — overload Linux emulator infra (timeouts, 503s). Re-evaluate after
-  # the critical-review items for fixture lifetime / partition count land.
-  #   FakeCosmosHandlerPartitionKeyTests   — 22m33s, ServiceUnavailable 503/1007 (run 24628925580)
-  #   FakeCosmosHandlerLinqTests           — Linux job cancelled at 45-min timeout (run 24629750138)
-  #   FakeCosmosHandlerCrudHardeningTests  — Linux job cancelled at 45-min timeout (run 24630621582)
-  #   FakeCosmosHandlerBulkTests           — Linux job cancelled at 45-min timeout (run 24631630911)
+  PARITY_FILTER: ${{ inputs.filter || 'FullyQualifiedName~FakeCosmosHandlerCrudTests|FullyQualifiedName~FakeCosmosHandlerTtlTests|FullyQualifiedName~FakeCosmosHandlerBatchTests|FullyQualifiedName~FakeCosmosHandlerQueryAdvancedTests|FullyQualifiedName~Issue18ExceptionTypeTests|FullyQualifiedName~Issue18EdgeCaseIntegrationTests' }}
+  # Note: Linux emulator job is commented out below. See #51 for details:
+  #   https://github.com/lemonlion/CosmosDB.InMemoryEmulator/issues/51
 
 jobs:
   test-inmemory:
@@ -55,64 +51,71 @@ jobs:
           name: trx-inmemory
           path: test-results/
 
-  test-emulator-linux:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    services:
-      cosmosdb:
-        image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
-        ports:
-          - 8081:8081
-          - 10250-10256:10250-10256
-        env:
-          AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 5
-          AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "false"
-          AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE: "127.0.0.1"
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
-      - name: Wait for Cosmos DB Emulator
-        run: |
-          echo "Waiting for Cosmos DB Emulator HTTP endpoint..."
-          timeout=300
-          elapsed=0
-          while [ $elapsed -lt $timeout ]; do
-            status=$(curl -sk -o /dev/null -w "%{http_code}" https://localhost:8081/ 2>/dev/null || echo "000")
-            if [ "$status" = "200" ] || [ "$status" = "401" ]; then
-              echo "HTTP endpoint ready after ${elapsed}s (HTTP $status)"
-              break
-            fi
-            sleep 5
-            elapsed=$((elapsed + 5))
-            echo "Still waiting... (${elapsed}s)"
-          done
-          if [ $elapsed -ge $timeout ]; then
-            echo "::error::Cosmos DB Emulator did not start within ${timeout}s"
-            exit 1
-          fi
-
-      - name: Build
-        run: dotnet build CosmosDB.InMemoryEmulator.sln --configuration Release
-
-      - name: Run Tests (emulator-linux)
-        shell: pwsh
-        run: ./scripts/run-tests.ps1 -Target emulator-linux -Project integration -Filter $env:PARITY_FILTER
-
-      - name: Upload TRX
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: trx-emulator-linux
-          path: test-results/
+  # ──────────────────────────────────────────────────────────────────────────────
+  # Linux emulator job — DISABLED
+  # The Dockerized Linux Cosmos emulator on GitHub Actions runners produces 65s
+  # request timeouts (HTTP 408) on PATCH and query operations, causing the job to
+  # exceed any reasonable timeout. See #51 for investigation and re-enablement:
+  #   https://github.com/lemonlion/CosmosDB.InMemoryEmulator/issues/51
+  # ──────────────────────────────────────────────────────────────────────────────
+  # test-emulator-linux:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #
+  #   services:
+  #     cosmosdb:
+  #       image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
+  #       ports:
+  #         - 8081:8081
+  #         - 10250-10256:10250-10256
+  #       env:
+  #         AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 10
+  #         AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "false"
+  #         AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE: "127.0.0.1"
+  #
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #
+  #     - name: Setup .NET
+  #       uses: actions/setup-dotnet@v5
+  #       with:
+  #         dotnet-version: |
+  #           8.0.x
+  #           10.0.x
+  #
+  #     - name: Wait for Cosmos DB Emulator
+  #       run: |
+  #         echo "Waiting for Cosmos DB Emulator HTTP endpoint..."
+  #         timeout=300
+  #         elapsed=0
+  #         while [ $elapsed -lt $timeout ]; do
+  #           status=$(curl -sk -o /dev/null -w "%{http_code}" https://localhost:8081/ 2>/dev/null || echo "000")
+  #           if [ "$status" = "200" ] || [ "$status" = "401" ]; then
+  #             echo "HTTP endpoint ready after ${elapsed}s (HTTP $status)"
+  #             break
+  #           fi
+  #           sleep 5
+  #           elapsed=$((elapsed + 5))
+  #           echo "Still waiting... (${elapsed}s)"
+  #         done
+  #         if [ $elapsed -ge $timeout ]; then
+  #           echo "::error::Cosmos DB Emulator did not start within ${timeout}s"
+  #           exit 1
+  #         fi
+  #
+  #     - name: Build
+  #       run: dotnet build CosmosDB.InMemoryEmulator.sln --configuration Release
+  #
+  #     - name: Run Tests (emulator-linux)
+  #       shell: pwsh
+  #       run: ./scripts/run-tests.ps1 -Target emulator-linux -Project integration -Filter $env:PARITY_FILTER
+  #
+  #     - name: Upload TRX
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: trx-emulator-linux
+  #         path: test-results/
 
   test-windows:
     runs-on: windows-latest
@@ -171,7 +174,7 @@ jobs:
           path: test-results/
 
   compare:
-    needs: [test-inmemory, test-emulator-linux, test-windows]
+    needs: [test-inmemory, test-windows]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,44 @@
 - When fixing a bug, identify missing test coverage in and around the affected area and create that coverage — again following the TDD red-green-refactor cycle.
 - Fix any additional bugs discovered during that expanded test coverage work.
 
+## Reflection Policy
+
+- **Do not use reflection as a first resort.** Explore all public API options before considering reflection.
+- Reflection on internal/private members of external libraries (e.g., SDK backing fields) is fragile — it can break silently on library updates with no compile-time warning.
+- If reflection is genuinely the only viable approach after exhausting alternatives, it may be used — but:
+  - **The PR description must explicitly state in bold that reflection is used**, what it targets, and why no public API alternative exists.
+  - Add a code comment at the reflection site explaining the dependency and what would break if the internal member is renamed or removed.
+  - Prefer a graceful fallback (e.g., leave the value as null) over a hard failure if the reflected member is missing.
+
+## Behavioral Source Requirements
+
+Every piece of behavioral logic in the source code — status codes, validation rules, error conditions, side-effect semantics — **must** be backed by a verified source. This prevents accidental divergence from real Cosmos DB behavior.
+
+### Rules
+
+1. **Before implementing any behavioral logic**, find and verify the expected behavior from one of the approved sources listed below.
+2. **Add a code comment** at the implementation site citing the source (a short URL or description is sufficient). Example:
+   ```csharp
+   // Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-dotnet-create-item
+   //   "The Container.ReplaceItemAsync<> method requires the provided string for the id
+   //    parameter to match the unique identifier of the item parameter."
+   ```
+3. **If sources conflict** (e.g., the emulator behaves differently from the documentation), prefer the official documentation over observed emulator behavior. Document the discrepancy in a code comment and mark the relevant integration test with `[Trait(TestTraits.Target, TestTraits.InMemoryOnly)]`.
+4. **If no source can be found**, do not guess. Ask for guidance or raise a discussion in the PR.
+
+### Approved Behavioral Sources (in priority order)
+
+| Priority | Source | URL / Location |
+|----------|--------|----------------|
+| 1 | Azure Cosmos DB REST API reference | https://learn.microsoft.com/en-us/rest/api/cosmos-db/ |
+| 2 | Azure Cosmos DB .NET SDK API reference | https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos |
+| 3 | Azure Cosmos DB "How-to" guides | https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/ |
+| 4 | Azure Cosmos DB conceptual docs (OCC, partitioning, indexing, etc.) | https://learn.microsoft.com/en-us/azure/cosmos-db/ |
+| 5 | Azure Cosmos DB .NET SDK source code | https://github.com/Azure/azure-cosmos-dotnet-v3 |
+| 6 | Observed behavior on the Windows Cosmos DB Emulator | (local testing) |
+
+> **Note:** Source 6 (emulator observation) is the weakest evidence. The emulator has known bugs. Always cross-reference with sources 1–5 when possible.
+
 ## Versioning & Release
 
 - After every session of bug fixes is complete and the full test suite has passed, increment the patch version in `src/Directory.Build.props` (the single `<Version>` property shared by all three packages).

--- a/scripts/compare-trx.ps1
+++ b/scripts/compare-trx.ps1
@@ -27,9 +27,20 @@ function Parse-TrxFile([string]$Path) {
     $results = @{}
     $xml | Select-Xml '//t:UnitTestResult' -Namespace $ns | ForEach-Object {
         $node = $_.Node
-        $results[$node.testName] = $node.outcome
+        $results[$node.testName] = @{
+            Outcome      = $node.outcome
+            ErrorMessage = $node.Output.ErrorInfo.Message
+            StackTrace   = $node.Output.ErrorInfo.StackTrace
+        }
     }
     return $results
+}
+
+function Truncate([string]$text, [int]$maxLength = 100) {
+    if (-not $text) { return '' }
+    $oneLine = ($text -split "`n")[0].Trim()
+    if ($oneLine.Length -le $maxLength) { return $oneLine }
+    return $oneLine.Substring(0, $maxLength) + '…'
 }
 
 # --- Discover all TRX files ---
@@ -67,7 +78,7 @@ $rows = @()
 foreach ($test in $allTestNames) {
     $row = [ordered]@{ Test = $test }
     foreach ($name in $targets.Keys) {
-        $row[$name] = if ($targets[$name].ContainsKey($test)) { $targets[$name][$test] } else { '-' }
+        $row[$name] = if ($targets[$name].ContainsKey($test)) { $targets[$name][$test].Outcome } else { '-' }
     }
     $rows += [PSCustomObject]$row
 }
@@ -158,23 +169,69 @@ if ($OutputFormat -eq 'markdown') {
     Write-Output "|--------|-------|--------|--------|---------|"
     foreach ($name in $targets.Keys) {
         $data = $targets[$name]
-        $passed  = @($data.Values | Where-Object { $_ -eq 'Passed' }).Count
-        $failed  = @($data.Values | Where-Object { $_ -eq 'Failed' }).Count
-        $skipped = @($data.Values | Where-Object { $_ -eq 'NotExecuted' }).Count
+        $passed  = @($data.Values | Where-Object { $_.Outcome -eq 'Passed' }).Count
+        $failed  = @($data.Values | Where-Object { $_.Outcome -eq 'Failed' }).Count
+        $skipped = @($data.Values | Where-Object { $_.Outcome -eq 'NotExecuted' }).Count
         Write-Output "| $name | $($data.Count) | $passed | $failed | $skipped |"
     }
     Write-Output ""
 
-    # Suspects detail
+    # Suspects detail — summary table with short error + collapsible full details
     if ($suspects.Count -gt 0) {
         Write-Output "## 🔍 Suspects — In-Memory Passes, Emulator Fails"
         Write-Output ""
-        Write-Output "| Test | inmemory | $emulatorCols |"
-        Write-Output "|------|----------|$emulatorSep|"
+        Write-Output "| Test | $emulatorCols | Error |"
+        Write-Output "|------|$emulatorSep|-------|"
         foreach ($r in $suspects) {
             $vals = ($emulatorNames | ForEach-Object { Format-Outcome $r.$_ }) -join ' | '
-            Write-Output "| $($r.Test) | $(Format-Outcome $r.$baselineName) | $vals |"
+            # Pick the error message from the first failing emulator target
+            $errSnippet = ''
+            foreach ($eName in $emulatorNames) {
+                if ($r.$eName -eq 'Failed' -and $targets[$eName].ContainsKey($r.Test)) {
+                    $errSnippet = Truncate $targets[$eName][$r.Test].ErrorMessage 100
+                    break
+                }
+            }
+            Write-Output "| $($r.Test) | $vals | $errSnippet |"
         }
+        Write-Output ""
+
+        # Collapsible full error details per suspect
+        Write-Output "<details>"
+        Write-Output "<summary><b>Full error details for suspects</b></summary>"
+        Write-Output ""
+        foreach ($r in $suspects) {
+            $testName = $r.Test
+            Write-Output "### ``$testName``"
+            Write-Output ""
+            foreach ($eName in $emulatorNames) {
+                if ($r.$eName -ne 'Failed') { continue }
+                if (-not $targets[$eName].ContainsKey($testName)) { continue }
+                $info = $targets[$eName][$testName]
+                Write-Output "**$eName**"
+                Write-Output ""
+                if ($info.ErrorMessage) {
+                    Write-Output "``````"
+                    Write-Output $info.ErrorMessage
+                    Write-Output "``````"
+                }
+                if ($info.StackTrace) {
+                    # Show top 8 stack frames to keep it readable
+                    $frames = ($info.StackTrace -split "`n" | Where-Object { $_.Trim() }) | Select-Object -First 8
+                    Write-Output ""
+                    Write-Output "<details><summary>Stack trace</summary>"
+                    Write-Output ""
+                    Write-Output "``````"
+                    $frames | ForEach-Object { Write-Output $_ }
+                    Write-Output "``````"
+                    Write-Output "</details>"
+                }
+                Write-Output ""
+            }
+            Write-Output "---"
+            Write-Output ""
+        }
+        Write-Output "</details>"
         Write-Output ""
     }
 
@@ -225,9 +282,9 @@ if ($OutputFormat -eq 'markdown') {
     Write-Host "  Per-Target:" -ForegroundColor Cyan
     foreach ($name in $targets.Keys) {
         $data = $targets[$name]
-        $passed  = @($data.Values | Where-Object { $_ -eq 'Passed' }).Count
-        $failed  = @($data.Values | Where-Object { $_ -eq 'Failed' }).Count
-        $skipped = @($data.Values | Where-Object { $_ -eq 'NotExecuted' }).Count
+        $passed  = @($data.Values | Where-Object { $_.Outcome -eq 'Passed' }).Count
+        $failed  = @($data.Values | Where-Object { $_.Outcome -eq 'Failed' }).Count
+        $skipped = @($data.Values | Where-Object { $_.Outcome -eq 'NotExecuted' }).Count
         $color = if ($failed -gt 0) { 'Yellow' } else { 'Green' }
         Write-Host "    $($name.PadRight(20)) $passed passed, $failed failed, $skipped skipped" -ForegroundColor $color
     }
@@ -241,6 +298,14 @@ if ($OutputFormat -eq 'markdown') {
                 $o = $r.$eName; if ($o -ne 'Passed') { $parts += "$eName=$o" }
             }
             Write-Host "    - $($r.Test)  [$($parts -join ', ')]" -ForegroundColor Red
+            # Show error message from the first failing emulator
+            foreach ($eName in $emulatorNames) {
+                if ($r.$eName -eq 'Failed' -and $targets[$eName].ContainsKey($r.Test)) {
+                    $errMsg = Truncate $targets[$eName][$r.Test].ErrorMessage 150
+                    if ($errMsg) { Write-Host "      → $errMsg" -ForegroundColor DarkRed }
+                    break
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Extracted from #32 to reduce scope creep on the Issue #18 fix.

### Changes

**`emulator-parity.yml`**
- Disable Linux emulator job (see #51 for re-enablement investigation)
- Clean up `PARITY_FILTER` env variable comments
- Update `compare` job `needs` to remove Linux dependency

**`scripts/compare-trx.ps1`**
- Parse error message and stack trace from TRX results
- Add truncated error column to suspects summary table
- Add collapsible full error/stack trace details per suspect
- Show error snippet in console output mode

**`AGENTS.md`**
- Add Reflection Policy (prefer public APIs, require bold PR disclosure if reflection is used)
- Add Behavioral Source Requirements (all behavioral logic must cite a verified documentation source, with approved sources table in priority order)