### PR TITLE
Combined: v4.0.21 — Ternary parenthesization, EmulatorFlaky removal, string literal aliases, FilterPredicate, insertion order, decimal scale + cross-platform CI

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -85,3 +85,20 @@ jobs:
 
       - name: Integration Tests
         run: dotnet test tests/CosmosDB.InMemoryEmulator.Tests.Integration --configuration Release --no-build --verbosity normal --framework ${{ matrix.framework }}
+
+  test-integration-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [net8.0, net10.0]
+    name: integration-windows (${{ matrix.framework }})
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-dotnet-build
+        with:
+          build-args: --framework ${{ matrix.framework }}
+
+      - name: Integration Tests
+        shell: bash
+        run: dotnet test tests/CosmosDB.InMemoryEmulator.Tests.Integration --configuration Release --no-build --verbosity normal --framework ${{ matrix.framework }}

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [net8.0, net10.0]
-    name: integration (${{ matrix.framework }})
+    name: integration-linux (${{ matrix.framework }})
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-dotnet-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,43 @@ Tests are split into two projects. When creating or moving tests, follow these r
 ### Key constraint
 The Integration project does **not** have `InternalsVisibleTo` access. If a test needs internal APIs, it belongs in Unit.
 
+## Publishing & Releases
+
+Packages are published to NuGet via the `release.yml` GitHub Actions workflow, triggered by pushing a `v*` tag. The workflow runs the full test suite before publishing — if tests fail, nothing is published.
+
+### Beta / Prerelease
+
+To publish a prerelease package for testing before merging:
+
+1. Ensure your fix is committed and pushed to a branch.
+2. Create and push a tag with a prerelease suffix:
+   ```bash
+   git tag v4.0.18-beta.1
+   git push origin v4.0.18-beta.1
+   ```
+3. The workflow extracts the version from the tag (strips the `v` prefix), passes it to `dotnet pack -p:Version=...`, and publishes to NuGet as a prerelease package.
+4. Consumers install with: `dotnet add package CosmosDB.InMemoryEmulator --version 4.0.18-beta.1`
+
+The tag can be on any branch — the workflow checks out the tagged commit.
+
+### Stable Release
+
+After merging to `main`:
+
+1. Ensure `src/Directory.Build.props` has the correct `<Version>` (e.g. `4.0.18`).
+2. Commit, create a tag, and push:
+   ```bash
+   git tag v4.0.18
+   git push origin v4.0.18
+   ```
+3. The workflow publishes stable packages and creates a GitHub Release with auto-generated release notes.
+
+### Version Conventions
+
+- `Directory.Build.props` `<Version>` is the target stable version — increment the patch after each release.
+- The CI workflow **overrides** the version from the tag, so the `.props` value doesn't need to match beta suffixes.
+- Prerelease format: `X.Y.Z-beta.N` (increment N for successive betas of the same version).
+
 ## Documentation
 
 After any changes are made that might effect the public API or functionality, documentation must be updated to reflect those changes.  The documentation should be clear and comprehensive, covering all new features, changes to existing features, and any deprecations or removals.  This includes updating README file (if relevant), but mainly the wiki which can be found in a sister folder to the main repository - ../CosmosDB.InMemoryEmulator.wiki.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.21] - 2026-05-27
-
-### Fixed
-- Decimal scale not preserved on round-trip (Issue #75). Whole numbers stored as decimals (e.g. `1500m`) gained a trailing `.0` after retrieval. A custom `CosmosJsonWriter` now normalizes JSON numeric representations during `ParseJson` to match real Cosmos DB behavior: whole numbers serialize as integers, fractional values use minimal representation (trailing zeros stripped).
-- SUM aggregate returns inconsistent results across platforms (Issue #75). On Linux, `SUM` of whole numbers returned `750.0` instead of `750` because `List<double>.Sum()` always returns `double`. Aggregate assignment points now normalize whole-number doubles to longs before serialization.
-- Aggregate queries fail on Linux with "Underlying object does not have an 'payload' field" error. On non-Windows platforms the Cosmos SDK's native `ServiceInterop` DLL is unavailable, causing the SDK to request a query plan and activate its `AggregateQueryPipelineStage`. The query plan strategy now suppresses all aggregate info so the SDK never enters this pipeline — our handler already computes aggregates directly.
-- Double-to-long overflow when normalizing values at the `long.MaxValue` boundary. `(double)long.MaxValue` rounds up to 2^63 which overflows on cast; comparison changed from `<=` to strict `<`.
-
-## [4.0.20] - 2026-05-20
+## [4.0.20] - 2026-05-27
 
 ### Fixed
 - `COUNT(expr)` with nested ternary expressions no longer miscounts documents (Issue #64). `ExprToString` in `CosmosSqlParser` did not parenthesise ternary/coalesce sub-expressions when they appeared as operands of higher-precedence binary operators. When the SDK's transformed query was round-tripped through `SimplifySdkQuery`, the missing parentheses caused re-parsing to produce a different AST — e.g. `(innerTernary > 0) ? 1 : undefined` became `innerTernary ? val : (otherVal > 0 ? 1 : undefined)` — making `COUNT` evaluate the wrong condition. The fix wraps ternary and coalesce expressions in parentheses whenever they appear inside binary, unary, BETWEEN, IN, or LIKE operators.
 - String literal aliases in aggregate queries (e.g. `SELECT 'Settlement' AS Label, COUNT(1) AS ItemCount FROM c`) no longer return `null` on Linux (Issue #67). `ProjectAggregateFields` now evaluates literal/expression fields via `EvaluateSqlExpression` instead of treating them as property paths. `DefaultQueryPlanStrategy` also bypasses the SDK aggregate pipeline when literals appear alongside aggregates.
 - Patch operations with filter predicates referencing non-existent properties no longer throw (Issue #70). Missing properties are now treated as `null` in `FilterPredicate` evaluation, matching real Cosmos DB behavior.
 - Queries without `ORDER BY` now return documents in insertion order, matching real Cosmos DB behavior (Issue #72). Previously documents were returned in hash-map order due to `ConcurrentDictionary` enumeration. Added insertion-order tracking to `InMemoryContainer` that maintains document position across create, replace, upsert, and delete operations.
+- Decimal scale not preserved on round-trip (Issue #75). Whole numbers stored as decimals (e.g. `1500m`) gained a trailing `.0` after retrieval. A custom `CosmosJsonWriter` now normalizes JSON numeric representations during `ParseJson` to match real Cosmos DB behavior: whole numbers serialize as integers, fractional values use minimal representation (trailing zeros stripped).
+- SUM aggregate returns inconsistent results across platforms (Issue #75). On Linux, `SUM` of whole numbers returned `750.0` instead of `750` because `List<double>.Sum()` always returns `double`. Aggregate assignment points now normalize whole-number doubles to longs before serialization.
+- Aggregate queries fail on Linux with "Underlying object does not have an 'payload' field" error. On non-Windows platforms the Cosmos SDK's native `ServiceInterop` DLL is unavailable, causing the SDK to request a query plan and activate its `AggregateQueryPipelineStage`. The query plan strategy now suppresses all aggregate info so the SDK never enters this pipeline — our handler already computes aggregates directly.
+- Double-to-long overflow when normalizing values at the `long.MaxValue` boundary. `(double)long.MaxValue` rounds up to 2^63 which overflows on cast; comparison changed from `<=` to strict `<`.
 
 ### Changed
 - Removed `EmulatorFlaky` trait. The single flaky test (`ConcurrentReadsOfNonExistent`) now uses adaptive concurrency — 50 parallel reads for in-memory, 10 for emulator targets — eliminating the need for blanket test exclusions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.18] - 2026-05-15
+
+### Fixed
+- `COUNT(expr)` with nested ternary expressions no longer miscounts documents (Issue #64). `ExprToString` in `CosmosSqlParser` did not parenthesise ternary/coalesce sub-expressions when they appeared as operands of higher-precedence binary operators. When the SDK's transformed query was round-tripped through `SimplifySdkQuery`, the missing parentheses caused re-parsing to produce a different AST — e.g. `(innerTernary > 0) ? 1 : undefined` became `innerTernary ? val : (otherVal > 0 ? 1 : undefined)` — making `COUNT` evaluate the wrong condition. The fix wraps ternary and coalesce expressions in parentheses whenever they appear inside binary, unary, BETWEEN, IN, or LIKE operators.
+
 ## [4.0.17] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.21] - 2026-05-27
+
+### Fixed
+- Decimal scale not preserved on round-trip (Issue #75). Whole numbers stored as decimals (e.g. `1500m`) gained a trailing `.0` after retrieval. A custom `CosmosJsonWriter` now normalizes JSON numeric representations during `ParseJson` to match real Cosmos DB behavior: whole numbers serialize as integers, fractional values use minimal representation (trailing zeros stripped).
+- SUM aggregate returns inconsistent results across platforms (Issue #75). On Linux, `SUM` of whole numbers returned `750.0` instead of `750` because `List<double>.Sum()` always returns `double`. Aggregate assignment points now normalize whole-number doubles to longs before serialization.
+- Aggregate queries fail on Linux with "Underlying object does not have an 'payload' field" error. On non-Windows platforms the Cosmos SDK's native `ServiceInterop` DLL is unavailable, causing the SDK to request a query plan and activate its `AggregateQueryPipelineStage`. The query plan strategy now suppresses all aggregate info so the SDK never enters this pipeline — our handler already computes aggregates directly.
+- Double-to-long overflow when normalizing values at the `long.MaxValue` boundary. `(double)long.MaxValue` rounds up to 2^63 which overflows on cast; comparison changed from `<=` to strict `<`.
+
 ## [4.0.20] - 2026-05-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.18] - 2026-05-15
+
+### Fixed
+- Queries without `ORDER BY` now return documents in insertion order, matching real Cosmos DB behavior (Issue #72). Previously documents were returned in hash-map order due to `ConcurrentDictionary` enumeration. Added insertion-order tracking to `InMemoryContainer` that maintains document position across create, replace, upsert, and delete operations.
+
 ## [4.0.17] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.18] - 2026-05-15
+## [4.0.18] - 2026-05-19
 
 ### Fixed
 - `COUNT(expr)` with nested ternary expressions no longer miscounts documents (Issue #64). `ExprToString` in `CosmosSqlParser` did not parenthesise ternary/coalesce sub-expressions when they appeared as operands of higher-precedence binary operators. When the SDK's transformed query was round-tripped through `SimplifySdkQuery`, the missing parentheses caused re-parsing to produce a different AST — e.g. `(innerTernary > 0) ? 1 : undefined` became `innerTernary ? val : (otherVal > 0 ? 1 : undefined)` — making `COUNT` evaluate the wrong condition. The fix wraps ternary and coalesce expressions in parentheses whenever they appear inside binary, unary, BETWEEN, IN, or LIKE operators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.18] - 2026-05-19
+## [4.0.20] - 2026-05-20
 
 ### Fixed
 - `COUNT(expr)` with nested ternary expressions no longer miscounts documents (Issue #64). `ExprToString` in `CosmosSqlParser` did not parenthesise ternary/coalesce sub-expressions when they appeared as operands of higher-precedence binary operators. When the SDK's transformed query was round-tripped through `SimplifySdkQuery`, the missing parentheses caused re-parsing to produce a different AST — e.g. `(innerTernary > 0) ? 1 : undefined` became `innerTernary ? val : (otherVal > 0 ? 1 : undefined)` — making `COUNT` evaluate the wrong condition. The fix wraps ternary and coalesce expressions in parentheses whenever they appear inside binary, unary, BETWEEN, IN, or LIKE operators.
+- String literal aliases in aggregate queries (e.g. `SELECT 'Settlement' AS Label, COUNT(1) AS ItemCount FROM c`) no longer return `null` on Linux (Issue #67). `ProjectAggregateFields` now evaluates literal/expression fields via `EvaluateSqlExpression` instead of treating them as property paths. `DefaultQueryPlanStrategy` also bypasses the SDK aggregate pipeline when literals appear alongside aggregates.
+- Patch operations with filter predicates referencing non-existent properties no longer throw (Issue #70). Missing properties are now treated as `null` in `FilterPredicate` evaluation, matching real Cosmos DB behavior.
 - Queries without `ORDER BY` now return documents in insertion order, matching real Cosmos DB behavior (Issue #72). Previously documents were returned in hash-map order due to `ConcurrentDictionary` enumeration. Added insertion-order tracking to `InMemoryContainer` that maintains document position across create, replace, upsert, and delete operations.
+
+### Changed
+- Removed `EmulatorFlaky` trait. The single flaky test (`ConcurrentReadsOfNonExistent`) now uses adaptive concurrency — 50 parallel reads for in-memory, 10 for emulator targets — eliminating the need for blanket test exclusions.
+
+### CI
+- Integration tests now run on **both** `ubuntu-latest` and `windows-latest` to catch platform-specific divergences (e.g. ServiceInterop vs non-ServiceInterop code paths).
 
 ## [4.0.17] - 2026-05-14
 

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -44,13 +44,10 @@ if ($Target -ne 'inmemory') {
     Remove-Item Env:COSMOS_EMULATOR_ENDPOINT -ErrorAction SilentlyContinue
 }
 
-# Build filter: exclude InMemoryOnly and EmulatorFlaky tests when targeting an emulator.
-# EmulatorFlaky tags tests that pass on in-memory but fail reproducibly on the Linux
-# Docker / Windows Cosmos DB emulators due to emulator-side instability — the behaviour
-# is still validated on the inmemory target, so excluding here just keeps CI signal clean.
+# Build filter: exclude InMemoryOnly tests when targeting an emulator.
 $filterExpr = ''
 if ($Target -ne 'inmemory') {
-    $filterExpr = 'Target!=InMemoryOnly&Target!=EmulatorFlaky'
+    $filterExpr = 'Target!=InMemoryOnly'
 }
 if ($Filter) {
     if ($filterExpr -and $Filter -match '\|') {

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -78,10 +78,7 @@ if ($needsIntegrationWarmup) {
     Write-Host "`nPre-creating emulator containers from manifest..." -ForegroundColor Cyan
     # `dotnet run` self-builds if needed — the warmup tool isn't in the solution,
     # so it's not covered by the workflow's solution-level build step.
-    # NuGetAudit is disabled because the dev container may not have internet access
-    # (e.g. linux+emulator-linux uses network_mode: service:emulator) and NU1900
-    # becomes a build error via TreatWarningsAsErrors.
-    & dotnet run --project $warmupProject --configuration Release -p:NuGetAudit=false -- $manifestPath
+    & dotnet run --project $warmupProject --configuration Release -- $manifestPath
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Emulator warmup failed with exit code $LASTEXITCODE" -ForegroundColor Red
         exit $LASTEXITCODE

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -78,7 +78,10 @@ if ($needsIntegrationWarmup) {
     Write-Host "`nPre-creating emulator containers from manifest..." -ForegroundColor Cyan
     # `dotnet run` self-builds if needed — the warmup tool isn't in the solution,
     # so it's not covered by the workflow's solution-level build step.
-    & dotnet run --project $warmupProject --configuration Release -- $manifestPath
+    # NuGetAudit is disabled because the dev container may not have internet access
+    # (e.g. linux+emulator-linux uses network_mode: service:emulator) and NU1900
+    # becomes a build error via TreatWarningsAsErrors.
+    & dotnet run --project $warmupProject --configuration Release -p:NuGetAudit=false -- $manifestPath
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Emulator warmup failed with exit code $LASTEXITCODE" -ForegroundColor Red
         exit $LASTEXITCODE

--- a/src/CosmosDB.InMemoryEmulator/CosmosSqlParser.cs
+++ b/src/CosmosDB.InMemoryEmulator/CosmosSqlParser.cs
@@ -13,74 +13,74 @@ namespace CosmosDB.InMemoryEmulator;
 
 public enum CosmosSqlToken
 {
-    // Keywords
-    Select,
-    Distinct,
-    Top,
-    Value,
-    As,
-    From,
-    Join,
-    In,
-    Where,
-    And,
-    Or,
-    Not,
-    Between,
-    Like,
-    Is,
-    Null,
-    Defined,
-    Undefined,
-    True,
-    False,
-    Exists,
-    Order,
-    By,
-    Asc,
-    Desc,
-    Group,
-    Having,
-    Offset,
-    Limit,
-    Array,
-    Escape,
+	// Keywords
+	Select,
+	Distinct,
+	Top,
+	Value,
+	As,
+	From,
+	Join,
+	In,
+	Where,
+	And,
+	Or,
+	Not,
+	Between,
+	Like,
+	Is,
+	Null,
+	Defined,
+	Undefined,
+	True,
+	False,
+	Exists,
+	Order,
+	By,
+	Asc,
+	Desc,
+	Group,
+	Having,
+	Offset,
+	Limit,
+	Array,
+	Escape,
 
-    // Literals & identifiers
-    Identifier,
-    StringLiteral,
-    DoubleQuotedString,
-    NumberLiteral,
-    Parameter,
+	// Literals & identifiers
+	Identifier,
+	StringLiteral,
+	DoubleQuotedString,
+	NumberLiteral,
+	Parameter,
 
-    // Operators & punctuation
-    Star,
-    Comma,
-    Dot,
-    OpenParen,
-    CloseParen,
-    OpenBracket,
-    CloseBracket,
-    Equals,
-    NotEquals,
-    LessThanOrEqual,
-    GreaterThanOrEqual,
-    LessThan,
-    GreaterThan,
-    Plus,
-    Minus,
-    Slash,
-    Percent,
-    Ampersand,
-    Pipe,
-    Caret,
-    Tilde,
-    QuestionQuestion,
-    Question,
-    Colon,
-    DoublePipe,
-    OpenBrace,
-    CloseBrace,
+	// Operators & punctuation
+	Star,
+	Comma,
+	Dot,
+	OpenParen,
+	CloseParen,
+	OpenBracket,
+	CloseBracket,
+	Equals,
+	NotEquals,
+	LessThanOrEqual,
+	GreaterThanOrEqual,
+	LessThan,
+	GreaterThan,
+	Plus,
+	Minus,
+	Slash,
+	Percent,
+	Ampersand,
+	Pipe,
+	Caret,
+	Tilde,
+	QuestionQuestion,
+	Question,
+	Colon,
+	DoublePipe,
+	OpenBrace,
+	CloseBrace,
 }
 
 // ──────────────────────────────────────────────
@@ -89,13 +89,13 @@ public enum CosmosSqlToken
 
 public enum ComparisonOp
 {
-    Equal,
-    NotEqual,
-    LessThan,
-    GreaterThan,
-    LessThanOrEqual,
-    GreaterThanOrEqual,
-    Like,
+	Equal,
+	NotEqual,
+	LessThan,
+	GreaterThan,
+	LessThanOrEqual,
+	GreaterThanOrEqual,
+	Like,
 }
 
 public sealed record SelectField(string Expression, string Alias, SqlExpression SqlExpr = null);
@@ -151,17 +151,17 @@ public sealed record ArrayLiteralExpression(SqlExpression[] Elements) : SqlExpre
 
 public enum BinaryOp
 {
-    Equal, NotEqual, LessThan, GreaterThan, LessThanOrEqual, GreaterThanOrEqual,
-    And, Or,
-    Add, Subtract, Multiply, Divide, Modulo,
-    BitwiseAnd, BitwiseOr, BitwiseXor,
-    Like,
-    StringConcat,
+	Equal, NotEqual, LessThan, GreaterThan, LessThanOrEqual, GreaterThanOrEqual,
+	And, Or,
+	Add, Subtract, Multiply, Divide, Modulo,
+	BitwiseAnd, BitwiseOr, BitwiseXor,
+	Like,
+	StringConcat,
 }
 
 public enum UnaryOp
 {
-    Not, Negate, BitwiseNot,
+	Not, Negate, BitwiseNot,
 }
 
 // ── Backward-compatible WhereExpression wrappers ──
@@ -185,26 +185,26 @@ public sealed record SqlExpressionCondition(SqlExpression Expression) : WhereExp
 // ── Query ──
 
 public sealed record CosmosSqlQuery(
-    SelectField[] SelectFields,
-    bool IsSelectAll,
-    int? TopCount,
-    string FromAlias,
-    JoinClause Join,
-    WhereExpression Where,
-    int? Offset,
-    int? Limit,
-    OrderByClause OrderBy = null,
-    bool IsDistinct = false,
-    bool IsValueSelect = false,
-    JoinClause[] Joins = null,
-    OrderByField[] OrderByFields = null,
-    string[] GroupByFields = null,
-    SqlExpression[] GroupByExpressions = null,
-    WhereExpression Having = null,
-    SqlExpression WhereExpr = null,
-    SqlExpression HavingExpr = null,
-    string FromSource = null,
-    SqlExpression RankExpression = null);
+	SelectField[] SelectFields,
+	bool IsSelectAll,
+	int? TopCount,
+	string FromAlias,
+	JoinClause Join,
+	WhereExpression Where,
+	int? Offset,
+	int? Limit,
+	OrderByClause OrderBy = null,
+	bool IsDistinct = false,
+	bool IsValueSelect = false,
+	JoinClause[] Joins = null,
+	OrderByField[] OrderByFields = null,
+	string[] GroupByFields = null,
+	SqlExpression[] GroupByExpressions = null,
+	WhereExpression Having = null,
+	SqlExpression WhereExpr = null,
+	SqlExpression HavingExpr = null,
+	string FromSource = null,
+	SqlExpression RankExpression = null);
 
 public sealed record OrderByClause(string Field, bool Ascending);
 
@@ -214,133 +214,133 @@ public sealed record OrderByClause(string Field, bool Ascending);
 
 public static class CosmosSqlTokenizer
 {
-    private static readonly TextParser<Unit> StringLiteralToken =
-        from open in Character.EqualTo('\'')
-        from content in Character.EqualTo('\'').Then(_ => Character.EqualTo('\'')).Try()
-            .Or(Character.Except('\''))
-            .Many()
-        from close in Character.EqualTo('\'')
-        select Unit.Value;
+	private static readonly TextParser<Unit> StringLiteralToken =
+		from open in Character.EqualTo('\'')
+		from content in Character.EqualTo('\'').Then(_ => Character.EqualTo('\'')).Try()
+			.Or(Character.Except('\''))
+			.Many()
+		from close in Character.EqualTo('\'')
+		select Unit.Value;
 
-    private static readonly TextParser<Unit> DoubleQuotedStringToken =
-        from open in Character.EqualTo('"')
-        from content in Character.Except('"').Many()
-        from close in Character.EqualTo('"')
-        select Unit.Value;
+	private static readonly TextParser<Unit> DoubleQuotedStringToken =
+		from open in Character.EqualTo('"')
+		from content in Character.Except('"').Many()
+		from close in Character.EqualTo('"')
+		select Unit.Value;
 
-    private static readonly TextParser<Unit> ParameterToken =
-        from at in Character.EqualTo('@')
-        from rest in Character.LetterOrDigit.Or(Character.EqualTo('_')).AtLeastOnce()
-        select Unit.Value;
+	private static readonly TextParser<Unit> ParameterToken =
+		from at in Character.EqualTo('@')
+		from rest in Character.LetterOrDigit.Or(Character.EqualTo('_')).AtLeastOnce()
+		select Unit.Value;
 
-    private static readonly TextParser<Unit> NumberToken =
-        (from number in Numerics.Decimal
-         from exp in (
-             from e in Character.EqualTo('e').Or(Character.EqualTo('E'))
-             from sign in Character.EqualTo('+').Or(Character.EqualTo('-')).OptionalOrDefault()
-             from digits in Character.Digit.AtLeastOnce()
-             select Unit.Value
-         ).OptionalOrDefault()
-         select Unit.Value);
+	private static readonly TextParser<Unit> NumberToken =
+		(from number in Numerics.Decimal
+		 from exp in (
+			 from e in Character.EqualTo('e').Or(Character.EqualTo('E'))
+			 from sign in Character.EqualTo('+').Or(Character.EqualTo('-')).OptionalOrDefault()
+			 from digits in Character.Digit.AtLeastOnce()
+			 select Unit.Value
+		 ).OptionalOrDefault()
+		 select Unit.Value);
 
-    // Ref: EF Core Cosmos provider uses $type as a discriminator column.
-    //   Allow $ as a valid identifier character to support queries like c.$type.
-    private static readonly TextParser<Unit> IdentOrKeyword =
-        from first in Character.Letter.Or(Character.EqualTo('_')).Or(Character.EqualTo('$'))
-        from rest in Character.LetterOrDigit.Or(Character.EqualTo('_')).Or(Character.EqualTo('$')).Many()
-        select Unit.Value;
+	// Ref: EF Core Cosmos provider uses $type as a discriminator column.
+	//   Allow $ as a valid identifier character to support queries like c.$type.
+	private static readonly TextParser<Unit> IdentOrKeyword =
+		from first in Character.Letter.Or(Character.EqualTo('_')).Or(Character.EqualTo('$'))
+		from rest in Character.LetterOrDigit.Or(Character.EqualTo('_')).Or(Character.EqualTo('$')).Many()
+		select Unit.Value;
 
-    // Quoted identifiers like [My Column] are not used by the Cosmos SDK's LINQ provider
-    // (it uses root["name"] with double-quoted strings instead). Removing this tokenizer rule
-    // allows [expr, expr] array literals and [0] numeric indexers to tokenize correctly.
-    // If needed in the future, require the content to contain a space to disambiguate.
+	// Quoted identifiers like [My Column] are not used by the Cosmos SDK's LINQ provider
+	// (it uses root["name"] with double-quoted strings instead). Removing this tokenizer rule
+	// allows [expr, expr] array literals and [0] numeric indexers to tokenize correctly.
+	// If needed in the future, require the content to contain a space to disambiguate.
 
-    private static readonly Dictionary<string, CosmosSqlToken> Keywords = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["SELECT"] = CosmosSqlToken.Select,
-        ["DISTINCT"] = CosmosSqlToken.Distinct,
-        ["TOP"] = CosmosSqlToken.Top,
-        ["VALUE"] = CosmosSqlToken.Value,
-        ["AS"] = CosmosSqlToken.As,
-        ["FROM"] = CosmosSqlToken.From,
-        ["JOIN"] = CosmosSqlToken.Join,
-        ["IN"] = CosmosSqlToken.In,
-        ["WHERE"] = CosmosSqlToken.Where,
-        ["AND"] = CosmosSqlToken.And,
-        ["OR"] = CosmosSqlToken.Or,
-        ["NOT"] = CosmosSqlToken.Not,
-        ["BETWEEN"] = CosmosSqlToken.Between,
-        ["LIKE"] = CosmosSqlToken.Like,
-        ["IS"] = CosmosSqlToken.Is,
-        ["NULL"] = CosmosSqlToken.Null,
-        ["DEFINED"] = CosmosSqlToken.Defined,
-        ["UNDEFINED"] = CosmosSqlToken.Undefined,
-        ["TRUE"] = CosmosSqlToken.True,
-        ["FALSE"] = CosmosSqlToken.False,
-        ["EXISTS"] = CosmosSqlToken.Exists,
-        ["ORDER"] = CosmosSqlToken.Order,
-        ["BY"] = CosmosSqlToken.By,
-        ["ASC"] = CosmosSqlToken.Asc,
-        ["DESC"] = CosmosSqlToken.Desc,
-        ["GROUP"] = CosmosSqlToken.Group,
-        ["HAVING"] = CosmosSqlToken.Having,
-        ["OFFSET"] = CosmosSqlToken.Offset,
-        ["LIMIT"] = CosmosSqlToken.Limit,
-        ["ARRAY"] = CosmosSqlToken.Array,
-        ["ESCAPE"] = CosmosSqlToken.Escape,
-    };
+	private static readonly Dictionary<string, CosmosSqlToken> Keywords = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["SELECT"] = CosmosSqlToken.Select,
+		["DISTINCT"] = CosmosSqlToken.Distinct,
+		["TOP"] = CosmosSqlToken.Top,
+		["VALUE"] = CosmosSqlToken.Value,
+		["AS"] = CosmosSqlToken.As,
+		["FROM"] = CosmosSqlToken.From,
+		["JOIN"] = CosmosSqlToken.Join,
+		["IN"] = CosmosSqlToken.In,
+		["WHERE"] = CosmosSqlToken.Where,
+		["AND"] = CosmosSqlToken.And,
+		["OR"] = CosmosSqlToken.Or,
+		["NOT"] = CosmosSqlToken.Not,
+		["BETWEEN"] = CosmosSqlToken.Between,
+		["LIKE"] = CosmosSqlToken.Like,
+		["IS"] = CosmosSqlToken.Is,
+		["NULL"] = CosmosSqlToken.Null,
+		["DEFINED"] = CosmosSqlToken.Defined,
+		["UNDEFINED"] = CosmosSqlToken.Undefined,
+		["TRUE"] = CosmosSqlToken.True,
+		["FALSE"] = CosmosSqlToken.False,
+		["EXISTS"] = CosmosSqlToken.Exists,
+		["ORDER"] = CosmosSqlToken.Order,
+		["BY"] = CosmosSqlToken.By,
+		["ASC"] = CosmosSqlToken.Asc,
+		["DESC"] = CosmosSqlToken.Desc,
+		["GROUP"] = CosmosSqlToken.Group,
+		["HAVING"] = CosmosSqlToken.Having,
+		["OFFSET"] = CosmosSqlToken.Offset,
+		["LIMIT"] = CosmosSqlToken.Limit,
+		["ARRAY"] = CosmosSqlToken.Array,
+		["ESCAPE"] = CosmosSqlToken.Escape,
+	};
 
-    private static readonly Tokenizer<CosmosSqlToken> Inner = new TokenizerBuilder<CosmosSqlToken>()
-        .Ignore(Span.WhiteSpace)
-        .Match(StringLiteralToken, CosmosSqlToken.StringLiteral)
-        .Match(DoubleQuotedStringToken, CosmosSqlToken.DoubleQuotedString)
-        .Match(ParameterToken, CosmosSqlToken.Parameter)
-        .Match(NumberToken, CosmosSqlToken.NumberLiteral)
-        .Match(IdentOrKeyword, CosmosSqlToken.Identifier)
-        .Match(Character.EqualTo('*'), CosmosSqlToken.Star)
-        .Match(Character.EqualTo(','), CosmosSqlToken.Comma)
-        .Match(Character.EqualTo('.'), CosmosSqlToken.Dot)
-        .Match(Character.EqualTo('('), CosmosSqlToken.OpenParen)
-        .Match(Character.EqualTo(')'), CosmosSqlToken.CloseParen)
-        .Match(Character.EqualTo('['), CosmosSqlToken.OpenBracket)
-        .Match(Character.EqualTo(']'), CosmosSqlToken.CloseBracket)
-        .Match(Span.EqualTo("!="), CosmosSqlToken.NotEquals)
-        .Match(Span.EqualTo("<>"), CosmosSqlToken.NotEquals)
-        .Match(Span.EqualTo("<="), CosmosSqlToken.LessThanOrEqual)
-        .Match(Span.EqualTo(">="), CosmosSqlToken.GreaterThanOrEqual)
-        .Match(Span.EqualTo("??"), CosmosSqlToken.QuestionQuestion)
-        .Match(Span.EqualTo("||"), CosmosSqlToken.DoublePipe)
-        .Match(Character.EqualTo('='), CosmosSqlToken.Equals)
-        .Match(Character.EqualTo('<'), CosmosSqlToken.LessThan)
-        .Match(Character.EqualTo('>'), CosmosSqlToken.GreaterThan)
-        .Match(Character.EqualTo('+'), CosmosSqlToken.Plus)
-        .Match(Character.EqualTo('-'), CosmosSqlToken.Minus)
-        .Match(Character.EqualTo('/'), CosmosSqlToken.Slash)
-        .Match(Character.EqualTo('%'), CosmosSqlToken.Percent)
-        .Match(Character.EqualTo('&'), CosmosSqlToken.Ampersand)
-        .Match(Character.EqualTo('|'), CosmosSqlToken.Pipe)
-        .Match(Character.EqualTo('^'), CosmosSqlToken.Caret)
-        .Match(Character.EqualTo('~'), CosmosSqlToken.Tilde)
-        .Match(Character.EqualTo('?'), CosmosSqlToken.Question)
-        .Match(Character.EqualTo(':'), CosmosSqlToken.Colon)
-        .Match(Character.EqualTo('{'), CosmosSqlToken.OpenBrace)
-        .Match(Character.EqualTo('}'), CosmosSqlToken.CloseBrace)
-        .Build();
+	private static readonly Tokenizer<CosmosSqlToken> Inner = new TokenizerBuilder<CosmosSqlToken>()
+		.Ignore(Span.WhiteSpace)
+		.Match(StringLiteralToken, CosmosSqlToken.StringLiteral)
+		.Match(DoubleQuotedStringToken, CosmosSqlToken.DoubleQuotedString)
+		.Match(ParameterToken, CosmosSqlToken.Parameter)
+		.Match(NumberToken, CosmosSqlToken.NumberLiteral)
+		.Match(IdentOrKeyword, CosmosSqlToken.Identifier)
+		.Match(Character.EqualTo('*'), CosmosSqlToken.Star)
+		.Match(Character.EqualTo(','), CosmosSqlToken.Comma)
+		.Match(Character.EqualTo('.'), CosmosSqlToken.Dot)
+		.Match(Character.EqualTo('('), CosmosSqlToken.OpenParen)
+		.Match(Character.EqualTo(')'), CosmosSqlToken.CloseParen)
+		.Match(Character.EqualTo('['), CosmosSqlToken.OpenBracket)
+		.Match(Character.EqualTo(']'), CosmosSqlToken.CloseBracket)
+		.Match(Span.EqualTo("!="), CosmosSqlToken.NotEquals)
+		.Match(Span.EqualTo("<>"), CosmosSqlToken.NotEquals)
+		.Match(Span.EqualTo("<="), CosmosSqlToken.LessThanOrEqual)
+		.Match(Span.EqualTo(">="), CosmosSqlToken.GreaterThanOrEqual)
+		.Match(Span.EqualTo("??"), CosmosSqlToken.QuestionQuestion)
+		.Match(Span.EqualTo("||"), CosmosSqlToken.DoublePipe)
+		.Match(Character.EqualTo('='), CosmosSqlToken.Equals)
+		.Match(Character.EqualTo('<'), CosmosSqlToken.LessThan)
+		.Match(Character.EqualTo('>'), CosmosSqlToken.GreaterThan)
+		.Match(Character.EqualTo('+'), CosmosSqlToken.Plus)
+		.Match(Character.EqualTo('-'), CosmosSqlToken.Minus)
+		.Match(Character.EqualTo('/'), CosmosSqlToken.Slash)
+		.Match(Character.EqualTo('%'), CosmosSqlToken.Percent)
+		.Match(Character.EqualTo('&'), CosmosSqlToken.Ampersand)
+		.Match(Character.EqualTo('|'), CosmosSqlToken.Pipe)
+		.Match(Character.EqualTo('^'), CosmosSqlToken.Caret)
+		.Match(Character.EqualTo('~'), CosmosSqlToken.Tilde)
+		.Match(Character.EqualTo('?'), CosmosSqlToken.Question)
+		.Match(Character.EqualTo(':'), CosmosSqlToken.Colon)
+		.Match(Character.EqualTo('{'), CosmosSqlToken.OpenBrace)
+		.Match(Character.EqualTo('}'), CosmosSqlToken.CloseBrace)
+		.Build();
 
-    public static TokenList<CosmosSqlToken> Tokenize(string input)
-    {
-        var tokens = Inner.Tokenize(input);
-        var remapped = tokens.Select(token =>
-        {
-            if (token.Kind == CosmosSqlToken.Identifier &&
-                Keywords.TryGetValue(token.Span.ToStringValue(), out var keyword))
-            {
-                return new Token<CosmosSqlToken>(keyword, token.Span);
-            }
-            return token;
-        }).ToArray();
-        return new TokenList<CosmosSqlToken>(remapped);
-    }
+	public static TokenList<CosmosSqlToken> Tokenize(string input)
+	{
+		var tokens = Inner.Tokenize(input);
+		var remapped = tokens.Select(token =>
+		{
+			if (token.Kind == CosmosSqlToken.Identifier &&
+				Keywords.TryGetValue(token.Span.ToStringValue(), out var keyword))
+			{
+				return new Token<CosmosSqlToken>(keyword, token.Span);
+			}
+			return token;
+		}).ToArray();
+		return new TokenList<CosmosSqlToken>(remapped);
+	}
 }
 
 // ──────────────────────────────────────────────
@@ -349,1152 +349,1164 @@ public static class CosmosSqlTokenizer
 
 public static class CosmosSqlParser
 {
-    private static readonly HashSet<string> LegacyFunctionNames = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "STARTSWITH", "ENDSWITH", "CONTAINS", "ARRAY_CONTAINS", "IS_DEFINED", "IS_NULL",
-    };
-
-    // ── Helpers ──
-
-    private static string TokenSpanToString(Token<CosmosSqlToken> token) =>
-        token.Span.ToStringValue();
-
-    private static TokenListParser<CosmosSqlToken, string> AnyIdentifierOrKeyword =>
-        Token.EqualTo(CosmosSqlToken.Identifier).Select(TokenSpanToString)
-            .Or(Token.EqualTo(CosmosSqlToken.Value).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Array).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Defined).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Asc).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Desc).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Top).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Limit).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Offset).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.Null).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.True).Select(TokenSpanToString))
-            .Or(Token.EqualTo(CosmosSqlToken.False).Select(TokenSpanToString));
-
-    // ── Dotted path: ident.ident.ident ──
-
-    private static readonly TokenListParser<CosmosSqlToken, string> DottedPath =
-        from first in AnyIdentifierOrKeyword
-        from rest in (
-            from dot in Token.EqualTo(CosmosSqlToken.Dot)
-            from next in AnyIdentifierOrKeyword
-            select "." + next
-        ).Many()
-        select first + string.Concat(rest);
-
-    // ── Dotted path with optional array indexing: ident.ident[0].ident ──
-
-    // Helper: a bracketed string inside [ ] can be single- or double-quoted
-    private static readonly TokenListParser<CosmosSqlToken, string> BracketedStringContent =
-        Token.EqualTo(CosmosSqlToken.StringLiteral).Select(t => t.Span.ToStringValue()[1..^1])
-            .Or(Token.EqualTo(CosmosSqlToken.DoubleQuotedString).Select(t => t.Span.ToStringValue()[1..^1]));
-
-    private static readonly TokenListParser<CosmosSqlToken, string> DottedPathWithIndex =
-        from first in AnyIdentifierOrKeyword
-        from rest in (
-            from dot in Token.EqualTo(CosmosSqlToken.Dot)
-            from next in AnyIdentifierOrKeyword
-            select "." + next
-        ).Or(
-            (from open in Token.EqualTo(CosmosSqlToken.OpenBracket)
-             from idx in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(TokenSpanToString)
-             from close in Token.EqualTo(CosmosSqlToken.CloseBracket)
-             select "[" + idx + "]").Try()
-        ).Or(
-            (from open in Token.EqualTo(CosmosSqlToken.OpenBracket)
-             from str in BracketedStringContent
-             from close in Token.EqualTo(CosmosSqlToken.CloseBracket)
-             select "." + str).Try()
-        ).Many()
-        select first + string.Concat(rest);
-
-    // ── Primary expression ──
-
-    // String literal expression: accepts both single-quoted (Cosmos SQL standard) and
-    // double-quoted strings (used by the SDK's LINQ provider in generated queries).
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> StringLiteral =
-        Token.EqualTo(CosmosSqlToken.StringLiteral)
-            .Select(t =>
-            {
-                var raw = t.Span.ToStringValue();
-                var unquoted = raw[1..^1].Replace("''", "'");
-                return (SqlExpression)new LiteralExpression(unquoted);
-            })
-        .Or(Token.EqualTo(CosmosSqlToken.DoubleQuotedString)
-            .Select(t =>
-            {
-                var raw = t.Span.ToStringValue();
-                var unquoted = raw[1..^1];
-                return (SqlExpression)new LiteralExpression(unquoted);
-            }));
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> NumberLiteral =
-        Token.EqualTo(CosmosSqlToken.NumberLiteral)
-            .Select(t =>
-            {
-                var raw = t.Span.ToStringValue();
-                if (long.TryParse(raw, out var longVal))
-                {
-                    return (SqlExpression)new LiteralExpression(longVal);
-                }
-
-                return (SqlExpression)new LiteralExpression(double.Parse(raw, System.Globalization.CultureInfo.InvariantCulture));
-            });
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> TrueLiteral =
-        Token.EqualTo(CosmosSqlToken.True).Select(_ => (SqlExpression)new LiteralExpression(true));
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> FalseLiteral =
-        Token.EqualTo(CosmosSqlToken.False).Select(_ => (SqlExpression)new LiteralExpression(false));
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> NullLiteral =
-        Token.EqualTo(CosmosSqlToken.Null).Select(_ => (SqlExpression)new LiteralExpression(null));
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> UndefinedLiteral =
-        Token.EqualTo(CosmosSqlToken.Undefined).Select(_ => (SqlExpression)new UndefinedLiteralExpression());
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ParameterExpr =
-        Token.EqualTo(CosmosSqlToken.Parameter)
-            .Select(t => (SqlExpression)new ParameterExpression(t.Span.ToStringValue()));
-
-    // Function call: FUNC_NAME(args...)
-    // Supports * as a function argument (e.g. COUNT(*))
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> FunctionCall =
-        from name in AnyIdentifierOrKeyword
-        from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-        from args in Token.EqualTo(CosmosSqlToken.Star).Select(_ => (SqlExpression)new IdentifierExpression("*"))
-            .Or(Superpower.Parse.Ref(() => Expr))
-            .ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-        from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-        select (SqlExpression)new FunctionCallExpression(name.ToUpperInvariant(), args);
-
-    // Dotted function call: namespace.FUNC_NAME(args...) — supports udf.xxx()
-    // UDF names preserve original casing (Cosmos DB UDFs are case-sensitive);
-    // built-in dotted functions (e.g. ST_DISTANCE) are uppercased.
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> DottedFunctionCall =
-        from first in AnyIdentifierOrKeyword
-        from dot in Token.EqualTo(CosmosSqlToken.Dot)
-        from second in AnyIdentifierOrKeyword
-        from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-        from args in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-        from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-        select (SqlExpression)new FunctionCallExpression(
-            first.Equals("udf", StringComparison.OrdinalIgnoreCase)
-                ? "UDF." + second   // preserve UDF name casing
-                : (first + "." + second).ToUpperInvariant(), args);
-
-    // EXISTS( subquery-text )
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ExistsExpr =
-        from kw in Token.EqualTo(CosmosSqlToken.Exists)
-        from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-        from inner in CaptureBalancedParens()
-        from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-        select (SqlExpression)new ExistsExpression(inner);
-
-    // Subquery expression: (SELECT ...) — a full SELECT statement inside parentheses
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> SubqueryParens =
-        from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-        from subquery in Superpower.Parse.Ref(() => QueryParser)
-        from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-        select (SqlExpression)new SubqueryExpression(subquery);
-
-    // Parenthesized expression (try subquery first, fall back to regular expression)
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Parens =
-        SubqueryParens.Try()
-        .Or(
-            from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-            from expr in Superpower.Parse.Ref(() => Expr)
-            from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-            select expr);
-
-    // Object literal: { key: expr, key: expr, ... }
-    // Keys can be identifiers or double-quoted strings (for SDK-generated queries like {"item": root.value})
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ObjectLiteral =
-        from open in Token.EqualTo(CosmosSqlToken.OpenBrace)
-        from props in (
-            from key in AnyIdentifierOrKeyword
-                .Or(Token.EqualTo(CosmosSqlToken.DoubleQuotedString).Select(t => t.Span.ToStringValue()[1..^1]))
-                .Or(Token.EqualTo(CosmosSqlToken.StringLiteral).Select(t => t.Span.ToStringValue()[1..^1]))
-            from colon in Token.EqualTo(CosmosSqlToken.Colon)
-            from value in Superpower.Parse.Ref(() => Expr)
-            select new KeyValuePair<string, SqlExpression>(key, value)
-        ).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-        from close in Token.EqualTo(CosmosSqlToken.CloseBrace)
-        select (SqlExpression)new ObjectLiteralExpression(props);
-
-    // Array literal: [ expr, expr, ... ]
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ArrayLiteral =
-        from open in Token.EqualTo(CosmosSqlToken.OpenBracket)
-        from elements in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-        from close in Token.EqualTo(CosmosSqlToken.CloseBracket)
-        select (SqlExpression)new ArrayLiteralExpression(elements);
-
-    // Identifier or dotted path
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> IdentExpr =
-        DottedPathWithIndex.Select(path => (SqlExpression)new IdentifierExpression(path));
-
-    // ARRAY(subquery): ARRAY keyword followed by a parenthesised SELECT
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ArraySubqueryCall =
-        from name in Token.EqualTo(CosmosSqlToken.Array)
-        from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-        from subquery in Superpower.Parse.Ref(() => QueryParser)
-        from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-        select (SqlExpression)new FunctionCallExpression("ARRAY", [new SubqueryExpression(subquery)]);
-
-    // Primary: literal | parameter | function call | exists | parens | object | array | ident
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Primary =
-        StringLiteral
-            .Or(NumberLiteral)
-            .Or(TrueLiteral)
-            .Or(FalseLiteral)
-            .Or(NullLiteral)
-            .Or(UndefinedLiteral)
-            .Or(ParameterExpr)
-            .Or(ExistsExpr.Try())
-            .Or(ArraySubqueryCall.Try())
-            .Or(DottedFunctionCall.Try())
-            .Or(FunctionCall.Try())
-            .Or(Parens)
-            .Or(ObjectLiteral.Try())
-            .Or(ArrayLiteral.Try())
-            .Or(IdentExpr);
-
-    // ── Unary ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> UnaryExpr =
-        (from op in Token.EqualTo(CosmosSqlToken.Not)
-         from operand in Superpower.Parse.Ref(() => UnaryExpr)
-         select (SqlExpression)new UnaryExpression(UnaryOp.Not, operand))
-        .Or(
-            from op in Token.EqualTo(CosmosSqlToken.Minus)
-            from operand in Primary
-            select (SqlExpression)new UnaryExpression(UnaryOp.Negate, operand))
-        .Or(
-            from op in Token.EqualTo(CosmosSqlToken.Tilde)
-            from operand in Primary
-            select (SqlExpression)new UnaryExpression(UnaryOp.BitwiseNot, operand))
-        .Or(Primary);
-
-    // ── Multiplicative: *, /, % ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Multiplicative =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.Star).Select(_ => BinaryOp.Multiply)
-                .Or(Token.EqualTo(CosmosSqlToken.Slash).Select(_ => BinaryOp.Divide))
-                .Or(Token.EqualTo(CosmosSqlToken.Percent).Select(_ => BinaryOp.Modulo)),
-            UnaryExpr,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Additive: +, - ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Additive =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.Plus).Select(_ => BinaryOp.Add)
-                .Or(Token.EqualTo(CosmosSqlToken.Minus).Select(_ => BinaryOp.Subtract)),
-            Multiplicative,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Bitwise AND: & ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> BitwiseAndExpr =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.Ampersand).Select(_ => BinaryOp.BitwiseAnd),
-            Additive,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Bitwise XOR: ^ ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> BitwiseXorExpr =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.Caret).Select(_ => BinaryOp.BitwiseXor),
-            BitwiseAndExpr,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Bitwise OR: | ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> BitwiseOrExpr =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.Pipe).Select(_ => BinaryOp.BitwiseOr),
-            BitwiseXorExpr,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── String concat: || ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> StringConcatExpr =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.DoublePipe).Select(_ => BinaryOp.StringConcat),
-            BitwiseOrExpr,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Comparison: =, !=, <, >, <=, >=, LIKE ──
-
-    private static readonly TokenListParser<CosmosSqlToken, BinaryOp> CompOp =
-        Token.EqualTo(CosmosSqlToken.Equals).Select(_ => BinaryOp.Equal)
-            .Or(Token.EqualTo(CosmosSqlToken.NotEquals).Select(_ => BinaryOp.NotEqual))
-            .Or(Token.EqualTo(CosmosSqlToken.LessThanOrEqual).Select(_ => BinaryOp.LessThanOrEqual))
-            .Or(Token.EqualTo(CosmosSqlToken.GreaterThanOrEqual).Select(_ => BinaryOp.GreaterThanOrEqual))
-            .Or(Token.EqualTo(CosmosSqlToken.LessThan).Select(_ => BinaryOp.LessThan))
-            .Or(Token.EqualTo(CosmosSqlToken.GreaterThan).Select(_ => BinaryOp.GreaterThan))
-            .Or(Token.EqualTo(CosmosSqlToken.Like).Select(_ => BinaryOp.Like));
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Comparison =
-        from left in StringConcatExpr
-        from rest in (
-            // BETWEEN low AND high
-            (from kw in Token.EqualTo(CosmosSqlToken.Between)
-             from low in StringConcatExpr
-             from and in Token.EqualTo(CosmosSqlToken.And)
-             from high in StringConcatExpr
-             select (Func<SqlExpression, SqlExpression>)(l => new BetweenExpression(l, low, high)))
-            // NOT BETWEEN low AND high
-            .Or(
-                (from not in Token.EqualTo(CosmosSqlToken.Not)
-                 from kw in Token.EqualTo(CosmosSqlToken.Between)
-                 from low in StringConcatExpr
-                 from and in Token.EqualTo(CosmosSqlToken.And)
-                 from high in StringConcatExpr
-                 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new BetweenExpression(l, low, high))))
-                .Try())
-            // IN (val, val, ...)
-            .Or(
-                from kw in Token.EqualTo(CosmosSqlToken.In)
-                from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-                from vals in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-                from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-                select (Func<SqlExpression, SqlExpression>)(l => new InExpression(l, vals)))
-            // NOT IN (val, val, ...)
-            .Or(
-                (from not in Token.EqualTo(CosmosSqlToken.Not)
-                from kw in Token.EqualTo(CosmosSqlToken.In)
-                from open in Token.EqualTo(CosmosSqlToken.OpenParen)
-                from vals in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-                from close in Token.EqualTo(CosmosSqlToken.CloseParen)
-                select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new InExpression(l, vals))))
-                .Try())
-            // LIKE pattern ESCAPE char
-            .Or(
-                (from kw in Token.EqualTo(CosmosSqlToken.Like)
-                 from pattern in StringConcatExpr
-                 from esc in Token.EqualTo(CosmosSqlToken.Escape)
-                 from escChar in Token.EqualTo(CosmosSqlToken.StringLiteral)
-                 select (Func<SqlExpression, SqlExpression>)(l => new LikeExpression(l, pattern, escChar.Span.ToStringValue()[1..^1])))
-                .Try())
-            // NOT LIKE pattern ESCAPE char
-            .Or(
-                (from not in Token.EqualTo(CosmosSqlToken.Not)
-                 from kw in Token.EqualTo(CosmosSqlToken.Like)
-                 from pattern in StringConcatExpr
-                 from esc in Token.EqualTo(CosmosSqlToken.Escape)
-                 from escChar in Token.EqualTo(CosmosSqlToken.StringLiteral)
-                 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new LikeExpression(l, pattern, escChar.Span.ToStringValue()[1..^1]))))
-                .Try())
-            // NOT LIKE pattern (without ESCAPE)
-            .Or(
-                (from not in Token.EqualTo(CosmosSqlToken.Not)
-                 from kw in Token.EqualTo(CosmosSqlToken.Like)
-                 from pattern in StringConcatExpr
-                 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new BinaryExpression(l, BinaryOp.Like, pattern))))
-                .Try())
-            // IS NOT NULL (must come before IS NULL to avoid consuming IS and failing on NOT)
-            .Or(
-                (from is_ in Token.EqualTo(CosmosSqlToken.Is)
-                from not_ in Token.EqualTo(CosmosSqlToken.Not)
-                from null_ in Token.EqualTo(CosmosSqlToken.Null)
-                select (Func<SqlExpression, SqlExpression>)(l => new BinaryExpression(l, BinaryOp.NotEqual, new LiteralExpression(null))))
-                .Try())
-            // IS NULL
-            .Or(
-                from is_ in Token.EqualTo(CosmosSqlToken.Is)
-                from null_ in Token.EqualTo(CosmosSqlToken.Null)
-                select (Func<SqlExpression, SqlExpression>)(l => new BinaryExpression(l, BinaryOp.Equal, new LiteralExpression(null))))
-            // op right
-            .Or(
-                from op in CompOp
-                from right in StringConcatExpr
-                select (Func<SqlExpression, SqlExpression>)(l => new BinaryExpression(l, op, right)))
-        ).OptionalOrDefault(null)
-        select rest != null ? rest(left) : left;
-
-    // ── Logical AND ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> AndExpr =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.And).Select(_ => BinaryOp.And),
-            Comparison,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Logical OR ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> OrExpr =
-        Superpower.Parse.Chain(
-            Token.EqualTo(CosmosSqlToken.Or).Select(_ => BinaryOp.Or),
-            AndExpr,
-            (op, left, right) => new BinaryExpression(left, op, right));
-
-    // ── Null coalesce: ?? ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> CoalesceExpr =
-        from left in OrExpr
-        from rest in (
-            from op in Token.EqualTo(CosmosSqlToken.QuestionQuestion)
-            from right in Superpower.Parse.Ref(() => CoalesceExpr)
-            select right
-        ).OptionalOrDefault(null)
-        select rest != null ? new CoalesceExpression(left, rest) : left;
-
-    // ── Ternary: cond ? then : else ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> TernaryExpr =
-        from cond in CoalesceExpr
-        from rest in (
-            from q in Token.EqualTo(CosmosSqlToken.Question)
-            from ifTrue in Superpower.Parse.Ref(() => Expr)
-            from colon in Token.EqualTo(CosmosSqlToken.Colon)
-            from ifFalse in Superpower.Parse.Ref(() => Expr)
-            select new { ifTrue, ifFalse }
-        ).OptionalOrDefault(null)
-        select rest != null ? (SqlExpression)new TernaryExpression(cond, rest.ifTrue, rest.ifFalse) : cond;
-
-    // ── Top-level expression ──
-
-    private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Expr = TernaryExpr;
-
-    // ──────────────────────────────────────────────
-    //  SELECT field parsing
-    // ──────────────────────────────────────────────
-
-    private static readonly TokenListParser<CosmosSqlToken, SelectField> StarField =
-        Token.EqualTo(CosmosSqlToken.Star).Select(_ => new SelectField("*", null));
-
-    // Handle "c.*" (alias DOT STAR) as equivalent to "*"
-    private static readonly TokenListParser<CosmosSqlToken, SelectField> AliasDotStarField =
-        from ident in AnyIdentifierOrKeyword
-        from dot in Token.EqualTo(CosmosSqlToken.Dot)
-        from star in Token.EqualTo(CosmosSqlToken.Star)
-        select new SelectField("*", null);
-
-    private static readonly TokenListParser<CosmosSqlToken, SelectField> ExpressionField =
-        from expr in Expr
-        from alias in (
-            from as_ in Token.EqualTo(CosmosSqlToken.As)
-            from name in AnyIdentifierOrKeyword
-            select name
-        ).OptionalOrDefault(null)
-        select new SelectField(ExprToString(expr), alias, expr);
-
-    private static readonly TokenListParser<CosmosSqlToken, SelectField> SingleSelectField =
-        StarField.Try().Or(AliasDotStarField.Try()).Or(ExpressionField);
-
-    // ──────────────────────────────────────────────
-    //  JOIN clause parsing
-    // ──────────────────────────────────────────────
-
-    private static readonly TokenListParser<CosmosSqlToken, JoinClause> JoinParser =
-        from kw in Token.EqualTo(CosmosSqlToken.Join)
-        from alias in AnyIdentifierOrKeyword
-        from in_ in Token.EqualTo(CosmosSqlToken.In)
-        from source in DottedPathWithIndex
-        select ParseJoinSource(alias, source);
-
-    // ──────────────────────────────────────────────
-    //  ORDER BY parsing
-    // ──────────────────────────────────────────────
-
-    private static readonly TokenListParser<CosmosSqlToken, OrderByField> OrderByFieldParser =
-        (from expr in Superpower.Parse.Ref(() => Expr)
-        from dir in Token.EqualTo(CosmosSqlToken.Asc).Select(_ => true)
-            .Or(Token.EqualTo(CosmosSqlToken.Desc).Select(_ => false))
-            .OptionalOrDefault(true)
-        select expr is IdentifierExpression ident
-            ? new OrderByField(ident.Name, dir)
-            : new OrderByField(null, dir, expr)).Try()
-        .Or(
-        from field in DottedPathWithIndex
-        from dir in Token.EqualTo(CosmosSqlToken.Asc).Select(_ => true)
-            .Or(Token.EqualTo(CosmosSqlToken.Desc).Select(_ => false))
-            .OptionalOrDefault(true)
-        select new OrderByField(field, dir));
-
-    // ──────────────────────────────────────────────
-    //  Full query parsing
-    // ──────────────────────────────────────────────
-
-    private static readonly TokenListParser<CosmosSqlToken, CosmosSqlQuery> QueryParser =
-        from select_ in Token.EqualTo(CosmosSqlToken.Select)
-        from distinct in Token.EqualTo(CosmosSqlToken.Distinct).OptionalOrDefault()
-        from top in (
-            from topKw in Token.EqualTo(CosmosSqlToken.Top)
-            from n in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(t => int.Parse(t.Span.ToStringValue()))
-            select (int?)n
-        ).OptionalOrDefault(null)
-        from value_ in Token.EqualTo(CosmosSqlToken.Value).OptionalOrDefault()
-        from fields in SingleSelectField.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-        from fromKw in Token.EqualTo(CosmosSqlToken.From)
-        from fromFirstIdent in AnyIdentifierOrKeyword
-        from fromClause in (
-            // FROM alias IN source.path
-            from in_ in Token.EqualTo(CosmosSqlToken.In)
-            from source in DottedPath
-            select (Alias: fromFirstIdent, Source: (string)source)
-        ).Try().Or(
-            // FROM source AS alias
-            from as_ in Token.EqualTo(CosmosSqlToken.As)
-            from alias in AnyIdentifierOrKeyword
-            select (Alias: alias, Source: (string)null)
-        ).Try().Or(
-            // FROM source alias  (implicit alias without AS keyword — only plain identifiers)
-            from alias in Token.EqualTo(CosmosSqlToken.Identifier).Select(TokenSpanToString)
-            select (Alias: alias, Source: (string)null)
-        ).Try().OptionalOrDefault((Alias: fromFirstIdent, Source: (string)null))
-        from joins in JoinParser.Many()
-        from where_ in (
-            from whereKw in Token.EqualTo(CosmosSqlToken.Where)
-            from expr in Expr
-            select expr
-        ).OptionalOrDefault(null)
-        from groupBy in (
-            from groupKw in Token.EqualTo(CosmosSqlToken.Group)
-            from byKw in Token.EqualTo(CosmosSqlToken.By)
-            from groupFields in Expr.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-            select groupFields
-        ).OptionalOrDefault(null)
-        from having in (
-            from havingKw in Token.EqualTo(CosmosSqlToken.Having)
-            from expr in Expr
-            select expr
-        ).OptionalOrDefault(null)
-        from orderByResult in (
-            from orderKw in Token.EqualTo(CosmosSqlToken.Order)
-            from byKw in Token.EqualTo(CosmosSqlToken.By)
-            from result in (
-                from rankKw in Token.EqualTo(CosmosSqlToken.Identifier)
-                    .Where(t => string.Equals(t.Span.ToStringValue(), "RANK", StringComparison.OrdinalIgnoreCase))
-                from expr in Expr
-                select (Fields: (OrderByField[])null, RankExpr: (SqlExpression)expr)
-            ).Try().Or(
-                from orderFields in OrderByFieldParser.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
-                select (Fields: orderFields, RankExpr: (SqlExpression)null)
-            )
-            select result
-        ).OptionalOrDefault(default)
-        from offset in (
-            from offsetKw in Token.EqualTo(CosmosSqlToken.Offset)
-            from n in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(t => int.Parse(t.Span.ToStringValue()))
-            select (int?)n
-        ).OptionalOrDefault(null)
-        from limit in (
-            from limitKw in Token.EqualTo(CosmosSqlToken.Limit)
-            from n in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(t => int.Parse(t.Span.ToStringValue()))
-            select (int?)n
-        ).OptionalOrDefault(null)
-        select BuildQuery(
-            distinct.HasValue, top, value_.HasValue, fields,
-            fromClause.Alias, fromClause.Source, joins, where_,
-            groupBy?.Select(ExprToString).ToArray(),
-            groupBy?.ToArray(),
-            having, orderByResult.Fields, offset, limit, orderByResult.RankExpr);
-
-    // ──────────────────────────────────────────────
-    //  Public API
-    // ──────────────────────────────────────────────
-
-    private const int ParseCacheMaxSize = 5000;
-    private static readonly ConcurrentDictionary<string, CosmosSqlQuery> ParseCache = new();
-
-    public static CosmosSqlQuery Parse(string sql)
-    {
-        if (ParseCache.TryGetValue(sql, out var cached))
-        {
-            return cached;
-        }
-
-        CosmosSqlQuery parsed;
-        try
-        {
-            var tokens = CosmosSqlTokenizer.Tokenize(sql);
-            parsed = QueryParser.Parse(tokens);
-        }
-        catch (Exception ex)
-        {
-            throw new NotSupportedException($"Failed to parse Cosmos SQL query: {sql}", ex);
-        }
-
-        if (ParseCache.Count < ParseCacheMaxSize)
-        {
-            ParseCache.TryAdd(sql, parsed);
-        }
-
-        return parsed;
-    }
-
-    public static bool TryParse(string sql, out CosmosSqlQuery result)
-    {
-        try
-        {
-            result = Parse(sql);
-            return true;
-        }
-        catch
-        {
-            result = null;
-            return false;
-        }
-    }
-
-    // Backward-compatible: convert SqlExpression tree to WhereExpression tree
-    public static WhereExpression ToWhereExpression(SqlExpression expr)
-    {
-        if (expr is null)
-        {
-            return null;
-        }
-
-        switch (expr)
-        {
-            case BinaryExpression bin when bin.Operator == BinaryOp.And:
-                return new AndCondition(ToWhereExpression(bin.Left), ToWhereExpression(bin.Right));
-
-            case BinaryExpression bin when bin.Operator == BinaryOp.Or:
-                return new OrCondition(ToWhereExpression(bin.Left), ToWhereExpression(bin.Right));
-
-            case UnaryExpression { Operator: UnaryOp.Not } unary:
-                return new NotCondition(ToWhereExpression(unary.Operand));
-
-            case ExistsExpression exists:
-                return new ExistsCondition(exists.RawSubquery);
-
-            case FunctionCallExpression func:
-                if (func.FunctionName.StartsWith("UDF.", StringComparison.OrdinalIgnoreCase) ||
-                    func.FunctionName.StartsWith("ST_", StringComparison.OrdinalIgnoreCase))
-                {
-                    return new SqlExpressionCondition(func);
-                }
-
-                var hasComplexArgs = func.Arguments.Any(a => a is ObjectLiteralExpression or ArrayLiteralExpression or FunctionCallExpression);
-                if (hasComplexArgs)
-                {
-                    return new SqlExpressionCondition(func);
-                }
-
-                if (LegacyFunctionNames.Contains(func.FunctionName))
-                {
-                    var args = func.Arguments.Select(ExprToString).ToArray();
-                    return new FunctionCondition(func.FunctionName, args);
-                }
-
-                return new SqlExpressionCondition(func);
-
-            case BinaryExpression bin when IsComparisonOp(bin.Operator):
-                if (ContainsFunctionCall(bin.Left) || ContainsFunctionCall(bin.Right) ||
-                    ContainsArithmetic(bin.Left) || ContainsArithmetic(bin.Right) ||
-                    ContainsComplexExpression(bin.Left) || ContainsComplexExpression(bin.Right))
-                {
-                    return new SqlExpressionCondition(bin);
-                }
-
-                var compOp = bin.Operator switch
-                {
-                    BinaryOp.Equal => ComparisonOp.Equal,
-                    BinaryOp.NotEqual => ComparisonOp.NotEqual,
-                    BinaryOp.LessThan => ComparisonOp.LessThan,
-                    BinaryOp.GreaterThan => ComparisonOp.GreaterThan,
-                    BinaryOp.LessThanOrEqual => ComparisonOp.LessThanOrEqual,
-                    BinaryOp.GreaterThanOrEqual => ComparisonOp.GreaterThanOrEqual,
-                    BinaryOp.Like => ComparisonOp.Like,
-                    _ => ComparisonOp.Equal,
-                };
-                return new ComparisonCondition(ExprToString(bin.Left), compOp, ExprToString(bin.Right));
-
-            default:
-                return new SqlExpressionCondition(expr);
-        }
-    }
-
-    /// <summary>
-    /// Removes SDK-injected <c>IS_DEFINED(alias)</c> and literal <c>true</c> nodes from
-    /// AND chains in a WHERE expression AST, returning the simplified user condition.
-    /// Only strips <c>IS_DEFINED()</c> calls whose argument is exactly the FROM alias
-    /// (the SDK injects <c>IS_DEFINED(root)</c> for ORDER BY, never <c>IS_DEFINED(root.field)</c>),
-    /// preserving any legitimate <c>IS_DEFINED()</c> from user code.
-    /// Returns <c>null</c> when the entire expression reduces to nothing.
-    /// </summary>
-    public static SqlExpression SimplifySdkWhereExpression(
-        SqlExpression expr, string fromAlias = null)
-    {
-        return SimplifyCore(expr, fromAlias);
-    }
-
-    private static SqlExpression SimplifyCore(SqlExpression expr, string fromAlias)
-    {
-        if (expr is null)
-        {
-            return null;
-        }
-
-        if (expr is LiteralExpression { Value: true })
-        {
-            return null;
-        }
-
-        if (expr is FunctionCallExpression func &&
-            string.Equals(func.FunctionName, "IS_DEFINED", StringComparison.OrdinalIgnoreCase) &&
-            func.Arguments.Length == 1)
-        {
-            var argStr = ExprToString(func.Arguments[0]);
-            // Only strip when: no alias specified (backward-compat), or arg IS the FROM alias exactly.
-            // The SDK injects IS_DEFINED(root) — never IS_DEFINED(root.field) — so this
-            // preserves any user-written IS_DEFINED on specific field paths.
-            if (fromAlias is null || string.Equals(argStr, fromAlias, StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-        }
-
-        if (expr is BinaryExpression { Operator: BinaryOp.And } and)
-        {
-            var left = SimplifyCore(and.Left, fromAlias);
-            var right = SimplifyCore(and.Right, fromAlias);
-            if (left is null && right is null)
-            {
-                return null;
-            }
-
-            if (left is null)
-            {
-                return right;
-            }
-
-            if (right is null)
-            {
-                return left;
-            }
-
-            return new BinaryExpression(left, BinaryOp.And, right);
-        }
-
-        return expr;
-    }
-
-    /// <summary>
-    /// Rebuilds a Superpower-parsed <see cref="CosmosSqlQuery"/> into clean SQL that
-    /// <see cref="InMemoryContainer"/> can execute. Strips SDK-injected WHERE clauses
-    /// (<c>IS_DEFINED(alias)</c>, literal <c>true</c>), normalises bracket notation
-    /// (<c>root["name"]</c>) to dot notation (<c>root.name</c>) via the AST, and
-    /// reconstructs SELECT, WHERE, ORDER BY, TOP, OFFSET/LIMIT, DISTINCT, and GROUP BY
-    /// clauses from the parsed structure.
-    /// <para>
-    /// For ORDER BY queries where the SDK rewrites the SELECT to include <c>orderByItems</c>
-    /// and <c>payload</c>, this emits <c>SELECT VALUE alias</c> to return full documents.
-    /// For all other queries, the original SELECT expressions are emitted from the AST.
-    /// </para>
-    /// </summary>
-    public static string SimplifySdkQuery(CosmosSqlQuery parsed)
-    {
-        var fromAlias = parsed.FromAlias;
-
-        var isOrderByQuery = parsed.SelectFields.Any(field =>
-            string.Equals(field.Alias, "orderByItems", StringComparison.OrdinalIgnoreCase));
-
-        // SELECT clause
-        var sb = new System.Text.StringBuilder("SELECT ");
-        if (parsed.IsDistinct)
-        {
-            sb.Append("DISTINCT ");
-        }
-
-        if (parsed.TopCount.HasValue)
-        {
-            sb.Append($"TOP {parsed.TopCount.Value} ");
-        }
-
-        if (isOrderByQuery)
-        {
-            sb.Append($"VALUE {fromAlias}");
-        }
-        else if (parsed.IsValueSelect)
-        {
-            var selectExprs = parsed.SelectFields
-                .Select(field => ExprToString(field.SqlExpr ?? new IdentifierExpression(field.Expression)))
-                .ToArray();
-            sb.Append("VALUE ");
-            sb.Append(string.Join(", ", selectExprs));
-        }
-        else if (parsed.IsSelectAll)
-        {
-            sb.Append('*');
-        }
-        else
-        {
-            var selectParts = parsed.SelectFields.Select(field =>
-            {
-                var expr = field.SqlExpr is not null ? ExprToString(field.SqlExpr) : field.Expression;
-                return field.Alias is not null ? $"{expr} AS {field.Alias}" : expr;
-            });
-            sb.Append(string.Join(", ", selectParts));
-        }
-
-        // FROM
-        if (parsed.FromSource is not null)
-        {
-            sb.Append($" FROM {fromAlias} IN {parsed.FromSource}");
-        }
-        else
-        {
-            sb.Append($" FROM {fromAlias}");
-        }
-
-        // JOINs
-        if (parsed.Joins is { Length: > 0 })
-        {
-            foreach (var join in parsed.Joins)
-            {
-                sb.Append($" JOIN {join.Alias} IN {join.SourceAlias}.{join.ArrayField}");
-            }
-        }
-
-        // WHERE — strip SDK-injected nodes
-        var simplifiedWhere = SimplifySdkWhereExpression(parsed.WhereExpr, fromAlias);
-        if (simplifiedWhere is not null)
-        {
-            sb.Append($" WHERE {ExprToString(simplifiedWhere)}");
-        }
-
-        // GROUP BY
-        if (parsed.GroupByFields is { Length: > 0 })
-        {
-            sb.Append($" GROUP BY {string.Join(", ", parsed.GroupByFields)}");
-        }
-
-        // HAVING
-        if (parsed.HavingExpr is not null)
-        {
-            sb.Append($" HAVING {ExprToString(parsed.HavingExpr)}");
-        }
-
-        // ORDER BY
-        if (parsed.OrderByFields is { Length: > 0 })
-        {
-            var orderByStr = string.Join(", ", parsed.OrderByFields.Select(field =>
-                $"{field.Field ?? ExprToString(field.Expression)} {(field.Ascending ? "ASC" : "DESC")}"));
-            sb.Append($" ORDER BY {orderByStr}");
-        }
-        else if (parsed.RankExpression is not null)
-        {
-            sb.Append($" ORDER BY RANK {ExprToString(parsed.RankExpression)}");
-        }
-
-        // OFFSET / LIMIT
-        if (parsed.Offset.HasValue)
-        {
-            sb.Append($" OFFSET {parsed.Offset.Value}");
-        }
-
-        if (parsed.Limit.HasValue)
-        {
-            sb.Append($" LIMIT {parsed.Limit.Value}");
-        }
-
-        return sb.ToString();
-    }
-
-    // ──────────────────────────────────────────────
-    //  Internal helpers
-    // ──────────────────────────────────────────────
-
-    internal static WhereExpression ParseWhereExpression(string expression)
-    {
-        var wrappedSql = $"SELECT * FROM c WHERE {expression}";
-        var query = Parse(wrappedSql);
-        return query.Where;
-    }
-
-    private static bool IsComparisonOp(BinaryOp op) =>
-        op is BinaryOp.Equal or BinaryOp.NotEqual or BinaryOp.LessThan or BinaryOp.GreaterThan
-            or BinaryOp.LessThanOrEqual or BinaryOp.GreaterThanOrEqual or BinaryOp.Like;
-
-    private static bool ContainsFunctionCall(SqlExpression expr) =>
-        expr switch
-        {
-            FunctionCallExpression => true,
-            BinaryExpression bin => ContainsFunctionCall(bin.Left) || ContainsFunctionCall(bin.Right),
-            UnaryExpression unary => ContainsFunctionCall(unary.Operand),
-            _ => false
-        };
-
-    private static bool ContainsArithmetic(SqlExpression expr) =>
-        expr switch
-        {
-            BinaryExpression bin when !IsComparisonOp(bin.Operator) => true,
-            BinaryExpression bin => ContainsArithmetic(bin.Left) || ContainsArithmetic(bin.Right),
-            UnaryExpression unary => ContainsArithmetic(unary.Operand),
-            _ => false
-        };
-
-    /// <summary>
-    /// Returns true when the expression contains a subquery, coalesce, or ternary —
-    /// any of which require full expression evaluation rather than string-based ResolveValue.
-    /// </summary>
-    private static bool ContainsComplexExpression(SqlExpression expr) =>
-        expr switch
-        {
-            SubqueryExpression => true,
-            CoalesceExpression => true,
-            TernaryExpression => true,
-            BinaryExpression bin => ContainsComplexExpression(bin.Left) || ContainsComplexExpression(bin.Right),
-            UnaryExpression unary => ContainsComplexExpression(unary.Operand),
-            _ => false
-        };
-
-    public static string ExprToString(SqlExpression expr)
-    {
-        return expr switch
-        {
-            LiteralExpression { Value: null } => "null",
-            LiteralExpression { Value: string s } => $"'{s}'",
-            LiteralExpression { Value: bool b } => b ? "true" : "false",
-            LiteralExpression lit => lit.Value?.ToString() ?? "null",
-            UndefinedLiteralExpression => "undefined",
-            IdentifierExpression ident => ident.Name,
-            ParameterExpression param => param.Name,
-            PropertyAccessExpression prop => $"{ExprToString(prop.Object)}.{prop.Property}",
-            IndexAccessExpression idx => $"{ExprToString(idx.Object)}[{ExprToString(idx.Index)}]",
-            FunctionCallExpression func => $"{func.FunctionName}({string.Join(", ", func.Arguments.Select(ExprToString))})",
-            BinaryExpression { Operator: BinaryOp.And or BinaryOp.Or } bin =>
-                $"({ExprToString(bin.Left)} {BinaryOpToString(bin.Operator)} {ExprToString(bin.Right)})",
-            BinaryExpression bin => $"{ExprToString(bin.Left)} {BinaryOpToString(bin.Operator)} {ExprToString(bin.Right)}",
-            UnaryExpression unary => $"{UnaryOpToString(unary.Operator)} {ExprToString(unary.Operand)}",
-            BetweenExpression betw => $"{ExprToString(betw.Value)} BETWEEN {ExprToString(betw.Low)} AND {ExprToString(betw.High)}",
-            InExpression inExpr => $"{ExprToString(inExpr.Value)} IN ({string.Join(", ", inExpr.List.Select(ExprToString))})",
-            LikeExpression like => like.EscapeChar is not null
-                ? $"{ExprToString(like.Value)} LIKE {ExprToString(like.Pattern)} ESCAPE '{like.EscapeChar}'"
-                : $"{ExprToString(like.Value)} LIKE {ExprToString(like.Pattern)}",
-            ExistsExpression exists => $"EXISTS({exists.RawSubquery})",
-            SubqueryExpression sub => $"({SubqueryToString(sub.Subquery)})",
-            TernaryExpression tern => $"{ExprToString(tern.Condition)} ? {ExprToString(tern.IfTrue)} : {ExprToString(tern.IfFalse)}",
-            CoalesceExpression coal => $"{ExprToString(coal.Left)} ?? {ExprToString(coal.Right)}",
-            ObjectLiteralExpression obj => "{" + string.Join(", ", obj.Properties.Select(p => $"{p.Key}: {ExprToString(p.Value)}")) + "}",
-            ArrayLiteralExpression arr => "[" + string.Join(", ", arr.Elements.Select(ExprToString)) + "]",
-            _ => expr.ToString(),
-        };
-    }
-
-    private static string SubqueryToString(CosmosSqlQuery sub)
-    {
-        var sb = new System.Text.StringBuilder("SELECT ");
-        if (sub.IsDistinct)
-        {
-            sb.Append("DISTINCT ");
-        }
-
-        if (sub.TopCount.HasValue)
-        {
-            sb.Append($"TOP {sub.TopCount.Value} ");
-        }
-
-        if (sub.IsValueSelect)
-        {
-            sb.Append("VALUE ");
-        }
-
-        if (sub.IsSelectAll)
-        {
-            sb.Append('*');
-        }
-        else
-        {
-            var selectParts = sub.SelectFields.Select(field =>
-            {
-                var expr = field.SqlExpr is not null ? ExprToString(field.SqlExpr) : field.Expression;
-                return field.Alias is not null ? $"{expr} AS {field.Alias}" : expr;
-            });
-            sb.Append(string.Join(", ", selectParts));
-        }
-
-        if (sub.FromSource is not null)
-        {
-            sb.Append($" FROM {sub.FromAlias} IN {sub.FromSource}");
-        }
-        else
-        {
-            sb.Append($" FROM {sub.FromAlias}");
-        }
-
-        if (sub.Joins is { Length: > 0 })
-        {
-            foreach (var join in sub.Joins)
-            {
-                sb.Append($" JOIN {join.Alias} IN {join.SourceAlias}.{join.ArrayField}");
-            }
-        }
-
-        if (sub.WhereExpr is not null)
-        {
-            sb.Append($" WHERE {ExprToString(sub.WhereExpr)}");
-        }
-
-        if (sub.GroupByFields is { Length: > 0 })
-        {
-            sb.Append($" GROUP BY {string.Join(", ", sub.GroupByFields)}");
-        }
-
-        if (sub.HavingExpr is not null)
-        {
-            sb.Append($" HAVING {ExprToString(sub.HavingExpr)}");
-        }
-
-        if (sub.OrderByFields is { Length: > 0 })
-        {
-            var orderByStr = string.Join(", ", sub.OrderByFields.Select(field =>
-                $"{field.Field} {(field.Ascending ? "ASC" : "DESC")}"));
-            sb.Append($" ORDER BY {orderByStr}");
-        }
-
-        if (sub.Offset.HasValue)
-        {
-            sb.Append($" OFFSET {sub.Offset.Value}");
-        }
-
-        if (sub.Limit.HasValue)
-        {
-            sb.Append($" LIMIT {sub.Limit.Value}");
-        }
-
-        return sb.ToString();
-    }
-
-    private static string BinaryOpToString(BinaryOp op) => op switch
-    {
-        BinaryOp.Equal => "=",
-        BinaryOp.NotEqual => "!=",
-        BinaryOp.LessThan => "<",
-        BinaryOp.GreaterThan => ">",
-        BinaryOp.LessThanOrEqual => "<=",
-        BinaryOp.GreaterThanOrEqual => ">=",
-        BinaryOp.And => "AND",
-        BinaryOp.Or => "OR",
-        BinaryOp.Add => "+",
-        BinaryOp.Subtract => "-",
-        BinaryOp.Multiply => "*",
-        BinaryOp.Divide => "/",
-        BinaryOp.Modulo => "%",
-        BinaryOp.Like => "LIKE",
-        BinaryOp.StringConcat => "||",
-        BinaryOp.BitwiseAnd => "&",
-        BinaryOp.BitwiseOr => "|",
-        BinaryOp.BitwiseXor => "^",
-        _ => op.ToString(),
-    };
-
-    private static string UnaryOpToString(UnaryOp op) => op switch
-    {
-        UnaryOp.Not => "NOT",
-        UnaryOp.Negate => "-",
-        UnaryOp.BitwiseNot => "~",
-        _ => op.ToString(),
-    };
-
-    private static JoinClause ParseJoinSource(string alias, string source)
-    {
-        var dotIdx = source.IndexOf('.');
-        if (dotIdx < 0)
-        {
-            return new JoinClause(alias, source, source);
-        }
-
-        return new JoinClause(alias, source[..dotIdx], source[(dotIdx + 1)..]);
-    }
-
-    private static CosmosSqlQuery BuildQuery(
-        bool isDistinct, int? top, bool isValue,
-        SelectField[] fields, string fromAlias, string fromSource,
-        JoinClause[] joins, SqlExpression whereExpr,
-        string[] groupBy, SqlExpression[] groupByExpressions, SqlExpression havingExpr,
-        OrderByField[] orderByFields,
-        int? offset, int? limit, SqlExpression rankExpr = null)
-    {
-        var isSelectAll = fields.Length == 1 && fields[0].Expression == "*";
-        var where = whereExpr != null ? ToWhereExpression(whereExpr) : null;
-        // HAVING always uses SqlExpressionCondition to preserve aggregate function expressions
-        // (ToWhereExpression would decompose AND/OR into AndCondition/OrCondition with string-based
-        // comparison operands, losing the ability to evaluate aggregate functions like COUNT/SUM).
-        var having = havingExpr != null ? new SqlExpressionCondition(havingExpr) : null;
-        var rawHavingExpr = havingExpr;
-
-        // Backward compat: first join, first order by
-        var firstJoin = joins.Length > 0 ? joins[0] : null;
-        OrderByClause legacyOrderBy = null;
-        if (orderByFields is { Length: > 0 })
-        {
-            legacyOrderBy = new OrderByClause(orderByFields[0].Field, orderByFields[0].Ascending);
-        }
-
-        return new CosmosSqlQuery(
-            SelectFields: fields,
-            IsSelectAll: isSelectAll,
-            TopCount: top,
-            FromAlias: fromAlias,
-            Join: firstJoin,
-            Where: where,
-            Offset: offset,
-            Limit: limit,
-            OrderBy: legacyOrderBy,
-            IsDistinct: isDistinct,
-            IsValueSelect: isValue,
-            Joins: joins,
-            OrderByFields: orderByFields,
-            GroupByFields: groupBy,
-            GroupByExpressions: groupByExpressions,
-            Having: having,
-            WhereExpr: whereExpr,
-            HavingExpr: rawHavingExpr,
-            FromSource: fromSource,
-            RankExpression: rankExpr);
-    }
-
-    // Captures tokens inside balanced parentheses as a raw string
-    private static TokenListParser<CosmosSqlToken, string> CaptureBalancedParens()
-    {
-        return input =>
-        {
-            var depth = 0;
-            var startPos = input.Position;
-            var current = input;
-            var parts = new List<string>();
-
-            while (!current.IsAtEnd)
-            {
-                var token = current.ConsumeToken();
-                if (!token.HasValue)
-                {
-                    break;
-                }
-
-                if (token.Value.Kind == CosmosSqlToken.OpenParen)
-                {
-                    depth++;
-                    parts.Add("(");
-                    current = token.Remainder;
-                }
-                else if (token.Value.Kind == CosmosSqlToken.CloseParen)
-                {
-                    if (depth == 0)
-                    {
-                        return TokenListParserResult.Value(string.Join(" ", parts), input, current);
-                    }
-                    depth--;
-                    parts.Add(")");
-                    current = token.Remainder;
-                }
-                else
-                {
-                    parts.Add(token.Value.Span.ToStringValue());
-                    current = token.Remainder;
-                }
-            }
-
-            return TokenListParserResult.Value(string.Join(" ", parts), input, current);
-        };
-    }
+	private static readonly HashSet<string> LegacyFunctionNames = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"STARTSWITH", "ENDSWITH", "CONTAINS", "ARRAY_CONTAINS", "IS_DEFINED", "IS_NULL",
+	};
+
+	// ── Helpers ──
+
+	private static string TokenSpanToString(Token<CosmosSqlToken> token) =>
+		token.Span.ToStringValue();
+
+	private static TokenListParser<CosmosSqlToken, string> AnyIdentifierOrKeyword =>
+		Token.EqualTo(CosmosSqlToken.Identifier).Select(TokenSpanToString)
+			.Or(Token.EqualTo(CosmosSqlToken.Value).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Array).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Defined).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Asc).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Desc).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Top).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Limit).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Offset).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.Null).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.True).Select(TokenSpanToString))
+			.Or(Token.EqualTo(CosmosSqlToken.False).Select(TokenSpanToString));
+
+	// ── Dotted path: ident.ident.ident ──
+
+	private static readonly TokenListParser<CosmosSqlToken, string> DottedPath =
+		from first in AnyIdentifierOrKeyword
+		from rest in (
+			from dot in Token.EqualTo(CosmosSqlToken.Dot)
+			from next in AnyIdentifierOrKeyword
+			select "." + next
+		).Many()
+		select first + string.Concat(rest);
+
+	// ── Dotted path with optional array indexing: ident.ident[0].ident ──
+
+	// Helper: a bracketed string inside [ ] can be single- or double-quoted
+	private static readonly TokenListParser<CosmosSqlToken, string> BracketedStringContent =
+		Token.EqualTo(CosmosSqlToken.StringLiteral).Select(t => t.Span.ToStringValue()[1..^1])
+			.Or(Token.EqualTo(CosmosSqlToken.DoubleQuotedString).Select(t => t.Span.ToStringValue()[1..^1]));
+
+	private static readonly TokenListParser<CosmosSqlToken, string> DottedPathWithIndex =
+		from first in AnyIdentifierOrKeyword
+		from rest in (
+			from dot in Token.EqualTo(CosmosSqlToken.Dot)
+			from next in AnyIdentifierOrKeyword
+			select "." + next
+		).Or(
+			(from open in Token.EqualTo(CosmosSqlToken.OpenBracket)
+			 from idx in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(TokenSpanToString)
+			 from close in Token.EqualTo(CosmosSqlToken.CloseBracket)
+			 select "[" + idx + "]").Try()
+		).Or(
+			(from open in Token.EqualTo(CosmosSqlToken.OpenBracket)
+			 from str in BracketedStringContent
+			 from close in Token.EqualTo(CosmosSqlToken.CloseBracket)
+			 select "." + str).Try()
+		).Many()
+		select first + string.Concat(rest);
+
+	// ── Primary expression ──
+
+	// String literal expression: accepts both single-quoted (Cosmos SQL standard) and
+	// double-quoted strings (used by the SDK's LINQ provider in generated queries).
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> StringLiteral =
+		Token.EqualTo(CosmosSqlToken.StringLiteral)
+			.Select(t =>
+			{
+				var raw = t.Span.ToStringValue();
+				var unquoted = raw[1..^1].Replace("''", "'");
+				return (SqlExpression)new LiteralExpression(unquoted);
+			})
+		.Or(Token.EqualTo(CosmosSqlToken.DoubleQuotedString)
+			.Select(t =>
+			{
+				var raw = t.Span.ToStringValue();
+				var unquoted = raw[1..^1];
+				return (SqlExpression)new LiteralExpression(unquoted);
+			}));
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> NumberLiteral =
+		Token.EqualTo(CosmosSqlToken.NumberLiteral)
+			.Select(t =>
+			{
+				var raw = t.Span.ToStringValue();
+				if (long.TryParse(raw, out var longVal))
+				{
+					return (SqlExpression)new LiteralExpression(longVal);
+				}
+
+				return (SqlExpression)new LiteralExpression(double.Parse(raw, System.Globalization.CultureInfo.InvariantCulture));
+			});
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> TrueLiteral =
+		Token.EqualTo(CosmosSqlToken.True).Select(_ => (SqlExpression)new LiteralExpression(true));
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> FalseLiteral =
+		Token.EqualTo(CosmosSqlToken.False).Select(_ => (SqlExpression)new LiteralExpression(false));
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> NullLiteral =
+		Token.EqualTo(CosmosSqlToken.Null).Select(_ => (SqlExpression)new LiteralExpression(null));
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> UndefinedLiteral =
+		Token.EqualTo(CosmosSqlToken.Undefined).Select(_ => (SqlExpression)new UndefinedLiteralExpression());
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ParameterExpr =
+		Token.EqualTo(CosmosSqlToken.Parameter)
+			.Select(t => (SqlExpression)new ParameterExpression(t.Span.ToStringValue()));
+
+	// Function call: FUNC_NAME(args...)
+	// Supports * as a function argument (e.g. COUNT(*))
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> FunctionCall =
+		from name in AnyIdentifierOrKeyword
+		from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+		from args in Token.EqualTo(CosmosSqlToken.Star).Select(_ => (SqlExpression)new IdentifierExpression("*"))
+			.Or(Superpower.Parse.Ref(() => Expr))
+			.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+		from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+		select (SqlExpression)new FunctionCallExpression(name.ToUpperInvariant(), args);
+
+	// Dotted function call: namespace.FUNC_NAME(args...) — supports udf.xxx()
+	// UDF names preserve original casing (Cosmos DB UDFs are case-sensitive);
+	// built-in dotted functions (e.g. ST_DISTANCE) are uppercased.
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> DottedFunctionCall =
+		from first in AnyIdentifierOrKeyword
+		from dot in Token.EqualTo(CosmosSqlToken.Dot)
+		from second in AnyIdentifierOrKeyword
+		from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+		from args in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+		from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+		select (SqlExpression)new FunctionCallExpression(
+			first.Equals("udf", StringComparison.OrdinalIgnoreCase)
+				? "UDF." + second   // preserve UDF name casing
+				: (first + "." + second).ToUpperInvariant(), args);
+
+	// EXISTS( subquery-text )
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ExistsExpr =
+		from kw in Token.EqualTo(CosmosSqlToken.Exists)
+		from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+		from inner in CaptureBalancedParens()
+		from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+		select (SqlExpression)new ExistsExpression(inner);
+
+	// Subquery expression: (SELECT ...) — a full SELECT statement inside parentheses
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> SubqueryParens =
+		from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+		from subquery in Superpower.Parse.Ref(() => QueryParser)
+		from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+		select (SqlExpression)new SubqueryExpression(subquery);
+
+	// Parenthesized expression (try subquery first, fall back to regular expression)
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Parens =
+		SubqueryParens.Try()
+		.Or(
+			from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+			from expr in Superpower.Parse.Ref(() => Expr)
+			from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+			select expr);
+
+	// Object literal: { key: expr, key: expr, ... }
+	// Keys can be identifiers or double-quoted strings (for SDK-generated queries like {"item": root.value})
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ObjectLiteral =
+		from open in Token.EqualTo(CosmosSqlToken.OpenBrace)
+		from props in (
+			from key in AnyIdentifierOrKeyword
+				.Or(Token.EqualTo(CosmosSqlToken.DoubleQuotedString).Select(t => t.Span.ToStringValue()[1..^1]))
+				.Or(Token.EqualTo(CosmosSqlToken.StringLiteral).Select(t => t.Span.ToStringValue()[1..^1]))
+			from colon in Token.EqualTo(CosmosSqlToken.Colon)
+			from value in Superpower.Parse.Ref(() => Expr)
+			select new KeyValuePair<string, SqlExpression>(key, value)
+		).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+		from close in Token.EqualTo(CosmosSqlToken.CloseBrace)
+		select (SqlExpression)new ObjectLiteralExpression(props);
+
+	// Array literal: [ expr, expr, ... ]
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ArrayLiteral =
+		from open in Token.EqualTo(CosmosSqlToken.OpenBracket)
+		from elements in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+		from close in Token.EqualTo(CosmosSqlToken.CloseBracket)
+		select (SqlExpression)new ArrayLiteralExpression(elements);
+
+	// Identifier or dotted path
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> IdentExpr =
+		DottedPathWithIndex.Select(path => (SqlExpression)new IdentifierExpression(path));
+
+	// ARRAY(subquery): ARRAY keyword followed by a parenthesised SELECT
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> ArraySubqueryCall =
+		from name in Token.EqualTo(CosmosSqlToken.Array)
+		from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+		from subquery in Superpower.Parse.Ref(() => QueryParser)
+		from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+		select (SqlExpression)new FunctionCallExpression("ARRAY", [new SubqueryExpression(subquery)]);
+
+	// Primary: literal | parameter | function call | exists | parens | object | array | ident
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Primary =
+		StringLiteral
+			.Or(NumberLiteral)
+			.Or(TrueLiteral)
+			.Or(FalseLiteral)
+			.Or(NullLiteral)
+			.Or(UndefinedLiteral)
+			.Or(ParameterExpr)
+			.Or(ExistsExpr.Try())
+			.Or(ArraySubqueryCall.Try())
+			.Or(DottedFunctionCall.Try())
+			.Or(FunctionCall.Try())
+			.Or(Parens)
+			.Or(ObjectLiteral.Try())
+			.Or(ArrayLiteral.Try())
+			.Or(IdentExpr);
+
+	// ── Unary ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> UnaryExpr =
+		(from op in Token.EqualTo(CosmosSqlToken.Not)
+		 from operand in Superpower.Parse.Ref(() => UnaryExpr)
+		 select (SqlExpression)new UnaryExpression(UnaryOp.Not, operand))
+		.Or(
+			from op in Token.EqualTo(CosmosSqlToken.Minus)
+			from operand in Primary
+			select (SqlExpression)new UnaryExpression(UnaryOp.Negate, operand))
+		.Or(
+			from op in Token.EqualTo(CosmosSqlToken.Tilde)
+			from operand in Primary
+			select (SqlExpression)new UnaryExpression(UnaryOp.BitwiseNot, operand))
+		.Or(Primary);
+
+	// ── Multiplicative: *, /, % ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Multiplicative =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.Star).Select(_ => BinaryOp.Multiply)
+				.Or(Token.EqualTo(CosmosSqlToken.Slash).Select(_ => BinaryOp.Divide))
+				.Or(Token.EqualTo(CosmosSqlToken.Percent).Select(_ => BinaryOp.Modulo)),
+			UnaryExpr,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Additive: +, - ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Additive =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.Plus).Select(_ => BinaryOp.Add)
+				.Or(Token.EqualTo(CosmosSqlToken.Minus).Select(_ => BinaryOp.Subtract)),
+			Multiplicative,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Bitwise AND: & ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> BitwiseAndExpr =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.Ampersand).Select(_ => BinaryOp.BitwiseAnd),
+			Additive,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Bitwise XOR: ^ ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> BitwiseXorExpr =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.Caret).Select(_ => BinaryOp.BitwiseXor),
+			BitwiseAndExpr,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Bitwise OR: | ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> BitwiseOrExpr =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.Pipe).Select(_ => BinaryOp.BitwiseOr),
+			BitwiseXorExpr,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── String concat: || ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> StringConcatExpr =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.DoublePipe).Select(_ => BinaryOp.StringConcat),
+			BitwiseOrExpr,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Comparison: =, !=, <, >, <=, >=, LIKE ──
+
+	private static readonly TokenListParser<CosmosSqlToken, BinaryOp> CompOp =
+		Token.EqualTo(CosmosSqlToken.Equals).Select(_ => BinaryOp.Equal)
+			.Or(Token.EqualTo(CosmosSqlToken.NotEquals).Select(_ => BinaryOp.NotEqual))
+			.Or(Token.EqualTo(CosmosSqlToken.LessThanOrEqual).Select(_ => BinaryOp.LessThanOrEqual))
+			.Or(Token.EqualTo(CosmosSqlToken.GreaterThanOrEqual).Select(_ => BinaryOp.GreaterThanOrEqual))
+			.Or(Token.EqualTo(CosmosSqlToken.LessThan).Select(_ => BinaryOp.LessThan))
+			.Or(Token.EqualTo(CosmosSqlToken.GreaterThan).Select(_ => BinaryOp.GreaterThan))
+			.Or(Token.EqualTo(CosmosSqlToken.Like).Select(_ => BinaryOp.Like));
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Comparison =
+		from left in StringConcatExpr
+		from rest in (
+			// BETWEEN low AND high
+			(from kw in Token.EqualTo(CosmosSqlToken.Between)
+			 from low in StringConcatExpr
+			 from and in Token.EqualTo(CosmosSqlToken.And)
+			 from high in StringConcatExpr
+			 select (Func<SqlExpression, SqlExpression>)(l => new BetweenExpression(l, low, high)))
+			// NOT BETWEEN low AND high
+			.Or(
+				(from not in Token.EqualTo(CosmosSqlToken.Not)
+				 from kw in Token.EqualTo(CosmosSqlToken.Between)
+				 from low in StringConcatExpr
+				 from and in Token.EqualTo(CosmosSqlToken.And)
+				 from high in StringConcatExpr
+				 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new BetweenExpression(l, low, high))))
+				.Try())
+			// IN (val, val, ...)
+			.Or(
+				from kw in Token.EqualTo(CosmosSqlToken.In)
+				from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+				from vals in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+				from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+				select (Func<SqlExpression, SqlExpression>)(l => new InExpression(l, vals)))
+			// NOT IN (val, val, ...)
+			.Or(
+				(from not in Token.EqualTo(CosmosSqlToken.Not)
+				 from kw in Token.EqualTo(CosmosSqlToken.In)
+				 from open in Token.EqualTo(CosmosSqlToken.OpenParen)
+				 from vals in Superpower.Parse.Ref(() => Expr).ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+				 from close in Token.EqualTo(CosmosSqlToken.CloseParen)
+				 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new InExpression(l, vals))))
+				.Try())
+			// LIKE pattern ESCAPE char
+			.Or(
+				(from kw in Token.EqualTo(CosmosSqlToken.Like)
+				 from pattern in StringConcatExpr
+				 from esc in Token.EqualTo(CosmosSqlToken.Escape)
+				 from escChar in Token.EqualTo(CosmosSqlToken.StringLiteral)
+				 select (Func<SqlExpression, SqlExpression>)(l => new LikeExpression(l, pattern, escChar.Span.ToStringValue()[1..^1])))
+				.Try())
+			// NOT LIKE pattern ESCAPE char
+			.Or(
+				(from not in Token.EqualTo(CosmosSqlToken.Not)
+				 from kw in Token.EqualTo(CosmosSqlToken.Like)
+				 from pattern in StringConcatExpr
+				 from esc in Token.EqualTo(CosmosSqlToken.Escape)
+				 from escChar in Token.EqualTo(CosmosSqlToken.StringLiteral)
+				 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new LikeExpression(l, pattern, escChar.Span.ToStringValue()[1..^1]))))
+				.Try())
+			// NOT LIKE pattern (without ESCAPE)
+			.Or(
+				(from not in Token.EqualTo(CosmosSqlToken.Not)
+				 from kw in Token.EqualTo(CosmosSqlToken.Like)
+				 from pattern in StringConcatExpr
+				 select (Func<SqlExpression, SqlExpression>)(l => new UnaryExpression(UnaryOp.Not, new BinaryExpression(l, BinaryOp.Like, pattern))))
+				.Try())
+			// IS NOT NULL (must come before IS NULL to avoid consuming IS and failing on NOT)
+			.Or(
+				(from is_ in Token.EqualTo(CosmosSqlToken.Is)
+				 from not_ in Token.EqualTo(CosmosSqlToken.Not)
+				 from null_ in Token.EqualTo(CosmosSqlToken.Null)
+				 select (Func<SqlExpression, SqlExpression>)(l => new BinaryExpression(l, BinaryOp.NotEqual, new LiteralExpression(null))))
+				.Try())
+			// IS NULL
+			.Or(
+				from is_ in Token.EqualTo(CosmosSqlToken.Is)
+				from null_ in Token.EqualTo(CosmosSqlToken.Null)
+				select (Func<SqlExpression, SqlExpression>)(l => new BinaryExpression(l, BinaryOp.Equal, new LiteralExpression(null))))
+			// op right
+			.Or(
+				from op in CompOp
+				from right in StringConcatExpr
+				select (Func<SqlExpression, SqlExpression>)(l => new BinaryExpression(l, op, right)))
+		).OptionalOrDefault(null)
+		select rest != null ? rest(left) : left;
+
+	// ── Logical AND ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> AndExpr =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.And).Select(_ => BinaryOp.And),
+			Comparison,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Logical OR ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> OrExpr =
+		Superpower.Parse.Chain(
+			Token.EqualTo(CosmosSqlToken.Or).Select(_ => BinaryOp.Or),
+			AndExpr,
+			(op, left, right) => new BinaryExpression(left, op, right));
+
+	// ── Null coalesce: ?? ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> CoalesceExpr =
+		from left in OrExpr
+		from rest in (
+			from op in Token.EqualTo(CosmosSqlToken.QuestionQuestion)
+			from right in Superpower.Parse.Ref(() => CoalesceExpr)
+			select right
+		).OptionalOrDefault(null)
+		select rest != null ? new CoalesceExpression(left, rest) : left;
+
+	// ── Ternary: cond ? then : else ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> TernaryExpr =
+		from cond in CoalesceExpr
+		from rest in (
+			from q in Token.EqualTo(CosmosSqlToken.Question)
+			from ifTrue in Superpower.Parse.Ref(() => Expr)
+			from colon in Token.EqualTo(CosmosSqlToken.Colon)
+			from ifFalse in Superpower.Parse.Ref(() => Expr)
+			select new { ifTrue, ifFalse }
+		).OptionalOrDefault(null)
+		select rest != null ? (SqlExpression)new TernaryExpression(cond, rest.ifTrue, rest.ifFalse) : cond;
+
+	// ── Top-level expression ──
+
+	private static readonly TokenListParser<CosmosSqlToken, SqlExpression> Expr = TernaryExpr;
+
+	// ──────────────────────────────────────────────
+	//  SELECT field parsing
+	// ──────────────────────────────────────────────
+
+	private static readonly TokenListParser<CosmosSqlToken, SelectField> StarField =
+		Token.EqualTo(CosmosSqlToken.Star).Select(_ => new SelectField("*", null));
+
+	// Handle "c.*" (alias DOT STAR) as equivalent to "*"
+	private static readonly TokenListParser<CosmosSqlToken, SelectField> AliasDotStarField =
+		from ident in AnyIdentifierOrKeyword
+		from dot in Token.EqualTo(CosmosSqlToken.Dot)
+		from star in Token.EqualTo(CosmosSqlToken.Star)
+		select new SelectField("*", null);
+
+	private static readonly TokenListParser<CosmosSqlToken, SelectField> ExpressionField =
+		from expr in Expr
+		from alias in (
+			from as_ in Token.EqualTo(CosmosSqlToken.As)
+			from name in AnyIdentifierOrKeyword
+			select name
+		).OptionalOrDefault(null)
+		select new SelectField(ExprToString(expr), alias, expr);
+
+	private static readonly TokenListParser<CosmosSqlToken, SelectField> SingleSelectField =
+		StarField.Try().Or(AliasDotStarField.Try()).Or(ExpressionField);
+
+	// ──────────────────────────────────────────────
+	//  JOIN clause parsing
+	// ──────────────────────────────────────────────
+
+	private static readonly TokenListParser<CosmosSqlToken, JoinClause> JoinParser =
+		from kw in Token.EqualTo(CosmosSqlToken.Join)
+		from alias in AnyIdentifierOrKeyword
+		from in_ in Token.EqualTo(CosmosSqlToken.In)
+		from source in DottedPathWithIndex
+		select ParseJoinSource(alias, source);
+
+	// ──────────────────────────────────────────────
+	//  ORDER BY parsing
+	// ──────────────────────────────────────────────
+
+	private static readonly TokenListParser<CosmosSqlToken, OrderByField> OrderByFieldParser =
+		(from expr in Superpower.Parse.Ref(() => Expr)
+		 from dir in Token.EqualTo(CosmosSqlToken.Asc).Select(_ => true)
+			 .Or(Token.EqualTo(CosmosSqlToken.Desc).Select(_ => false))
+			 .OptionalOrDefault(true)
+		 select expr is IdentifierExpression ident
+			 ? new OrderByField(ident.Name, dir)
+			 : new OrderByField(null, dir, expr)).Try()
+		.Or(
+		from field in DottedPathWithIndex
+		from dir in Token.EqualTo(CosmosSqlToken.Asc).Select(_ => true)
+			.Or(Token.EqualTo(CosmosSqlToken.Desc).Select(_ => false))
+			.OptionalOrDefault(true)
+		select new OrderByField(field, dir));
+
+	// ──────────────────────────────────────────────
+	//  Full query parsing
+	// ──────────────────────────────────────────────
+
+	private static readonly TokenListParser<CosmosSqlToken, CosmosSqlQuery> QueryParser =
+		from select_ in Token.EqualTo(CosmosSqlToken.Select)
+		from distinct in Token.EqualTo(CosmosSqlToken.Distinct).OptionalOrDefault()
+		from top in (
+			from topKw in Token.EqualTo(CosmosSqlToken.Top)
+			from n in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(t => int.Parse(t.Span.ToStringValue()))
+			select (int?)n
+		).OptionalOrDefault(null)
+		from value_ in Token.EqualTo(CosmosSqlToken.Value).OptionalOrDefault()
+		from fields in SingleSelectField.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+		from fromKw in Token.EqualTo(CosmosSqlToken.From)
+		from fromFirstIdent in AnyIdentifierOrKeyword
+		from fromClause in (
+			// FROM alias IN source.path
+			from in_ in Token.EqualTo(CosmosSqlToken.In)
+			from source in DottedPath
+			select (Alias: fromFirstIdent, Source: (string)source)
+		).Try().Or(
+			// FROM source AS alias
+			from as_ in Token.EqualTo(CosmosSqlToken.As)
+			from alias in AnyIdentifierOrKeyword
+			select (Alias: alias, Source: (string)null)
+		).Try().Or(
+			// FROM source alias  (implicit alias without AS keyword — only plain identifiers)
+			from alias in Token.EqualTo(CosmosSqlToken.Identifier).Select(TokenSpanToString)
+			select (Alias: alias, Source: (string)null)
+		).Try().OptionalOrDefault((Alias: fromFirstIdent, Source: (string)null))
+		from joins in JoinParser.Many()
+		from where_ in (
+			from whereKw in Token.EqualTo(CosmosSqlToken.Where)
+			from expr in Expr
+			select expr
+		).OptionalOrDefault(null)
+		from groupBy in (
+			from groupKw in Token.EqualTo(CosmosSqlToken.Group)
+			from byKw in Token.EqualTo(CosmosSqlToken.By)
+			from groupFields in Expr.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+			select groupFields
+		).OptionalOrDefault(null)
+		from having in (
+			from havingKw in Token.EqualTo(CosmosSqlToken.Having)
+			from expr in Expr
+			select expr
+		).OptionalOrDefault(null)
+		from orderByResult in (
+			from orderKw in Token.EqualTo(CosmosSqlToken.Order)
+			from byKw in Token.EqualTo(CosmosSqlToken.By)
+			from result in (
+				from rankKw in Token.EqualTo(CosmosSqlToken.Identifier)
+					.Where(t => string.Equals(t.Span.ToStringValue(), "RANK", StringComparison.OrdinalIgnoreCase))
+				from expr in Expr
+				select (Fields: (OrderByField[])null, RankExpr: (SqlExpression)expr)
+			).Try().Or(
+				from orderFields in OrderByFieldParser.ManyDelimitedBy(Token.EqualTo(CosmosSqlToken.Comma))
+				select (Fields: orderFields, RankExpr: (SqlExpression)null)
+			)
+			select result
+		).OptionalOrDefault(default)
+		from offset in (
+			from offsetKw in Token.EqualTo(CosmosSqlToken.Offset)
+			from n in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(t => int.Parse(t.Span.ToStringValue()))
+			select (int?)n
+		).OptionalOrDefault(null)
+		from limit in (
+			from limitKw in Token.EqualTo(CosmosSqlToken.Limit)
+			from n in Token.EqualTo(CosmosSqlToken.NumberLiteral).Select(t => int.Parse(t.Span.ToStringValue()))
+			select (int?)n
+		).OptionalOrDefault(null)
+		select BuildQuery(
+			distinct.HasValue, top, value_.HasValue, fields,
+			fromClause.Alias, fromClause.Source, joins, where_,
+			groupBy?.Select(ExprToString).ToArray(),
+			groupBy?.ToArray(),
+			having, orderByResult.Fields, offset, limit, orderByResult.RankExpr);
+
+	// ──────────────────────────────────────────────
+	//  Public API
+	// ──────────────────────────────────────────────
+
+	private const int ParseCacheMaxSize = 5000;
+	private static readonly ConcurrentDictionary<string, CosmosSqlQuery> ParseCache = new();
+
+	public static CosmosSqlQuery Parse(string sql)
+	{
+		if (ParseCache.TryGetValue(sql, out var cached))
+		{
+			return cached;
+		}
+
+		CosmosSqlQuery parsed;
+		try
+		{
+			var tokens = CosmosSqlTokenizer.Tokenize(sql);
+			parsed = QueryParser.Parse(tokens);
+		}
+		catch (Exception ex)
+		{
+			throw new NotSupportedException($"Failed to parse Cosmos SQL query: {sql}", ex);
+		}
+
+		if (ParseCache.Count < ParseCacheMaxSize)
+		{
+			ParseCache.TryAdd(sql, parsed);
+		}
+
+		return parsed;
+	}
+
+	public static bool TryParse(string sql, out CosmosSqlQuery result)
+	{
+		try
+		{
+			result = Parse(sql);
+			return true;
+		}
+		catch
+		{
+			result = null;
+			return false;
+		}
+	}
+
+	// Backward-compatible: convert SqlExpression tree to WhereExpression tree
+	public static WhereExpression ToWhereExpression(SqlExpression expr)
+	{
+		if (expr is null)
+		{
+			return null;
+		}
+
+		switch (expr)
+		{
+			case BinaryExpression bin when bin.Operator == BinaryOp.And:
+				return new AndCondition(ToWhereExpression(bin.Left), ToWhereExpression(bin.Right));
+
+			case BinaryExpression bin when bin.Operator == BinaryOp.Or:
+				return new OrCondition(ToWhereExpression(bin.Left), ToWhereExpression(bin.Right));
+
+			case UnaryExpression { Operator: UnaryOp.Not } unary:
+				return new NotCondition(ToWhereExpression(unary.Operand));
+
+			case ExistsExpression exists:
+				return new ExistsCondition(exists.RawSubquery);
+
+			case FunctionCallExpression func:
+				if (func.FunctionName.StartsWith("UDF.", StringComparison.OrdinalIgnoreCase) ||
+					func.FunctionName.StartsWith("ST_", StringComparison.OrdinalIgnoreCase))
+				{
+					return new SqlExpressionCondition(func);
+				}
+
+				var hasComplexArgs = func.Arguments.Any(a => a is ObjectLiteralExpression or ArrayLiteralExpression or FunctionCallExpression);
+				if (hasComplexArgs)
+				{
+					return new SqlExpressionCondition(func);
+				}
+
+				if (LegacyFunctionNames.Contains(func.FunctionName))
+				{
+					var args = func.Arguments.Select(ExprToString).ToArray();
+					return new FunctionCondition(func.FunctionName, args);
+				}
+
+				return new SqlExpressionCondition(func);
+
+			case BinaryExpression bin when IsComparisonOp(bin.Operator):
+				if (ContainsFunctionCall(bin.Left) || ContainsFunctionCall(bin.Right) ||
+					ContainsArithmetic(bin.Left) || ContainsArithmetic(bin.Right) ||
+					ContainsComplexExpression(bin.Left) || ContainsComplexExpression(bin.Right))
+				{
+					return new SqlExpressionCondition(bin);
+				}
+
+				var compOp = bin.Operator switch
+				{
+					BinaryOp.Equal => ComparisonOp.Equal,
+					BinaryOp.NotEqual => ComparisonOp.NotEqual,
+					BinaryOp.LessThan => ComparisonOp.LessThan,
+					BinaryOp.GreaterThan => ComparisonOp.GreaterThan,
+					BinaryOp.LessThanOrEqual => ComparisonOp.LessThanOrEqual,
+					BinaryOp.GreaterThanOrEqual => ComparisonOp.GreaterThanOrEqual,
+					BinaryOp.Like => ComparisonOp.Like,
+					_ => ComparisonOp.Equal,
+				};
+				return new ComparisonCondition(ExprToString(bin.Left), compOp, ExprToString(bin.Right));
+
+			default:
+				return new SqlExpressionCondition(expr);
+		}
+	}
+
+	/// <summary>
+	/// Removes SDK-injected <c>IS_DEFINED(alias)</c> and literal <c>true</c> nodes from
+	/// AND chains in a WHERE expression AST, returning the simplified user condition.
+	/// Only strips <c>IS_DEFINED()</c> calls whose argument is exactly the FROM alias
+	/// (the SDK injects <c>IS_DEFINED(root)</c> for ORDER BY, never <c>IS_DEFINED(root.field)</c>),
+	/// preserving any legitimate <c>IS_DEFINED()</c> from user code.
+	/// Returns <c>null</c> when the entire expression reduces to nothing.
+	/// </summary>
+	public static SqlExpression SimplifySdkWhereExpression(
+		SqlExpression expr, string fromAlias = null)
+	{
+		return SimplifyCore(expr, fromAlias);
+	}
+
+	private static SqlExpression SimplifyCore(SqlExpression expr, string fromAlias)
+	{
+		if (expr is null)
+		{
+			return null;
+		}
+
+		if (expr is LiteralExpression { Value: true })
+		{
+			return null;
+		}
+
+		if (expr is FunctionCallExpression func &&
+			string.Equals(func.FunctionName, "IS_DEFINED", StringComparison.OrdinalIgnoreCase) &&
+			func.Arguments.Length == 1)
+		{
+			var argStr = ExprToString(func.Arguments[0]);
+			// Only strip when: no alias specified (backward-compat), or arg IS the FROM alias exactly.
+			// The SDK injects IS_DEFINED(root) — never IS_DEFINED(root.field) — so this
+			// preserves any user-written IS_DEFINED on specific field paths.
+			if (fromAlias is null || string.Equals(argStr, fromAlias, StringComparison.OrdinalIgnoreCase))
+			{
+				return null;
+			}
+		}
+
+		if (expr is BinaryExpression { Operator: BinaryOp.And } and)
+		{
+			var left = SimplifyCore(and.Left, fromAlias);
+			var right = SimplifyCore(and.Right, fromAlias);
+			if (left is null && right is null)
+			{
+				return null;
+			}
+
+			if (left is null)
+			{
+				return right;
+			}
+
+			if (right is null)
+			{
+				return left;
+			}
+
+			return new BinaryExpression(left, BinaryOp.And, right);
+		}
+
+		return expr;
+	}
+
+	/// <summary>
+	/// Rebuilds a Superpower-parsed <see cref="CosmosSqlQuery"/> into clean SQL that
+	/// <see cref="InMemoryContainer"/> can execute. Strips SDK-injected WHERE clauses
+	/// (<c>IS_DEFINED(alias)</c>, literal <c>true</c>), normalises bracket notation
+	/// (<c>root["name"]</c>) to dot notation (<c>root.name</c>) via the AST, and
+	/// reconstructs SELECT, WHERE, ORDER BY, TOP, OFFSET/LIMIT, DISTINCT, and GROUP BY
+	/// clauses from the parsed structure.
+	/// <para>
+	/// For ORDER BY queries where the SDK rewrites the SELECT to include <c>orderByItems</c>
+	/// and <c>payload</c>, this emits <c>SELECT VALUE alias</c> to return full documents.
+	/// For all other queries, the original SELECT expressions are emitted from the AST.
+	/// </para>
+	/// </summary>
+	public static string SimplifySdkQuery(CosmosSqlQuery parsed)
+	{
+		var fromAlias = parsed.FromAlias;
+
+		var isOrderByQuery = parsed.SelectFields.Any(field =>
+			string.Equals(field.Alias, "orderByItems", StringComparison.OrdinalIgnoreCase));
+
+		// SELECT clause
+		var sb = new System.Text.StringBuilder("SELECT ");
+		if (parsed.IsDistinct)
+		{
+			sb.Append("DISTINCT ");
+		}
+
+		if (parsed.TopCount.HasValue)
+		{
+			sb.Append($"TOP {parsed.TopCount.Value} ");
+		}
+
+		if (isOrderByQuery)
+		{
+			sb.Append($"VALUE {fromAlias}");
+		}
+		else if (parsed.IsValueSelect)
+		{
+			var selectExprs = parsed.SelectFields
+				.Select(field => ExprToString(field.SqlExpr ?? new IdentifierExpression(field.Expression)))
+				.ToArray();
+			sb.Append("VALUE ");
+			sb.Append(string.Join(", ", selectExprs));
+		}
+		else if (parsed.IsSelectAll)
+		{
+			sb.Append('*');
+		}
+		else
+		{
+			var selectParts = parsed.SelectFields.Select(field =>
+			{
+				var expr = field.SqlExpr is not null ? ExprToString(field.SqlExpr) : field.Expression;
+				return field.Alias is not null ? $"{expr} AS {field.Alias}" : expr;
+			});
+			sb.Append(string.Join(", ", selectParts));
+		}
+
+		// FROM
+		if (parsed.FromSource is not null)
+		{
+			sb.Append($" FROM {fromAlias} IN {parsed.FromSource}");
+		}
+		else
+		{
+			sb.Append($" FROM {fromAlias}");
+		}
+
+		// JOINs
+		if (parsed.Joins is { Length: > 0 })
+		{
+			foreach (var join in parsed.Joins)
+			{
+				sb.Append($" JOIN {join.Alias} IN {join.SourceAlias}.{join.ArrayField}");
+			}
+		}
+
+		// WHERE — strip SDK-injected nodes
+		var simplifiedWhere = SimplifySdkWhereExpression(parsed.WhereExpr, fromAlias);
+		if (simplifiedWhere is not null)
+		{
+			sb.Append($" WHERE {ExprToString(simplifiedWhere)}");
+		}
+
+		// GROUP BY
+		if (parsed.GroupByFields is { Length: > 0 })
+		{
+			sb.Append($" GROUP BY {string.Join(", ", parsed.GroupByFields)}");
+		}
+
+		// HAVING
+		if (parsed.HavingExpr is not null)
+		{
+			sb.Append($" HAVING {ExprToString(parsed.HavingExpr)}");
+		}
+
+		// ORDER BY
+		if (parsed.OrderByFields is { Length: > 0 })
+		{
+			var orderByStr = string.Join(", ", parsed.OrderByFields.Select(field =>
+				$"{field.Field ?? ExprToString(field.Expression)} {(field.Ascending ? "ASC" : "DESC")}"));
+			sb.Append($" ORDER BY {orderByStr}");
+		}
+		else if (parsed.RankExpression is not null)
+		{
+			sb.Append($" ORDER BY RANK {ExprToString(parsed.RankExpression)}");
+		}
+
+		// OFFSET / LIMIT
+		if (parsed.Offset.HasValue)
+		{
+			sb.Append($" OFFSET {parsed.Offset.Value}");
+		}
+
+		if (parsed.Limit.HasValue)
+		{
+			sb.Append($" LIMIT {parsed.Limit.Value}");
+		}
+
+		return sb.ToString();
+	}
+
+	// ──────────────────────────────────────────────
+	//  Internal helpers
+	// ──────────────────────────────────────────────
+
+	internal static WhereExpression ParseWhereExpression(string expression)
+	{
+		var wrappedSql = $"SELECT * FROM c WHERE {expression}";
+		var query = Parse(wrappedSql);
+		return query.Where;
+	}
+
+	private static bool IsComparisonOp(BinaryOp op) =>
+		op is BinaryOp.Equal or BinaryOp.NotEqual or BinaryOp.LessThan or BinaryOp.GreaterThan
+			or BinaryOp.LessThanOrEqual or BinaryOp.GreaterThanOrEqual or BinaryOp.Like;
+
+	private static bool ContainsFunctionCall(SqlExpression expr) =>
+		expr switch
+		{
+			FunctionCallExpression => true,
+			BinaryExpression bin => ContainsFunctionCall(bin.Left) || ContainsFunctionCall(bin.Right),
+			UnaryExpression unary => ContainsFunctionCall(unary.Operand),
+			_ => false
+		};
+
+	private static bool ContainsArithmetic(SqlExpression expr) =>
+		expr switch
+		{
+			BinaryExpression bin when !IsComparisonOp(bin.Operator) => true,
+			BinaryExpression bin => ContainsArithmetic(bin.Left) || ContainsArithmetic(bin.Right),
+			UnaryExpression unary => ContainsArithmetic(unary.Operand),
+			_ => false
+		};
+
+	/// <summary>
+	/// Returns true when the expression contains a subquery, coalesce, or ternary —
+	/// any of which require full expression evaluation rather than string-based ResolveValue.
+	/// </summary>
+	private static bool ContainsComplexExpression(SqlExpression expr) =>
+		expr switch
+		{
+			SubqueryExpression => true,
+			CoalesceExpression => true,
+			TernaryExpression => true,
+			BinaryExpression bin => ContainsComplexExpression(bin.Left) || ContainsComplexExpression(bin.Right),
+			UnaryExpression unary => ContainsComplexExpression(unary.Operand),
+			_ => false
+		};
+
+	public static string ExprToString(SqlExpression expr)
+	{
+		return expr switch
+		{
+			LiteralExpression { Value: null } => "null",
+			LiteralExpression { Value: string s } => $"'{s}'",
+			LiteralExpression { Value: bool b } => b ? "true" : "false",
+			LiteralExpression lit => lit.Value?.ToString() ?? "null",
+			UndefinedLiteralExpression => "undefined",
+			IdentifierExpression ident => ident.Name,
+			ParameterExpression param => param.Name,
+			PropertyAccessExpression prop => $"{ExprToString(prop.Object)}.{prop.Property}",
+			IndexAccessExpression idx => $"{ExprToString(idx.Object)}[{ExprToString(idx.Index)}]",
+			FunctionCallExpression func => $"{func.FunctionName}({string.Join(", ", func.Arguments.Select(ExprToString))})",
+			BinaryExpression { Operator: BinaryOp.And or BinaryOp.Or } bin =>
+				$"({WrapIfLowPrecedence(bin.Left)} {BinaryOpToString(bin.Operator)} {WrapIfLowPrecedence(bin.Right)})",
+			BinaryExpression bin => $"{WrapIfLowPrecedence(bin.Left)} {BinaryOpToString(bin.Operator)} {WrapIfLowPrecedence(bin.Right)}",
+			UnaryExpression unary => $"{UnaryOpToString(unary.Operator)} {WrapIfLowPrecedence(unary.Operand)}",
+			BetweenExpression betw => $"{WrapIfLowPrecedence(betw.Value)} BETWEEN {ExprToString(betw.Low)} AND {ExprToString(betw.High)}",
+			InExpression inExpr => $"{WrapIfLowPrecedence(inExpr.Value)} IN ({string.Join(", ", inExpr.List.Select(ExprToString))})",
+			LikeExpression like => like.EscapeChar is not null
+				? $"{WrapIfLowPrecedence(like.Value)} LIKE {ExprToString(like.Pattern)} ESCAPE '{like.EscapeChar}'"
+				: $"{WrapIfLowPrecedence(like.Value)} LIKE {ExprToString(like.Pattern)}",
+			ExistsExpression exists => $"EXISTS({exists.RawSubquery})",
+			SubqueryExpression sub => $"({SubqueryToString(sub.Subquery)})",
+			TernaryExpression tern => $"{ExprToString(tern.Condition)} ? {ExprToString(tern.IfTrue)} : {ExprToString(tern.IfFalse)}",
+			CoalesceExpression coal => $"{ExprToString(coal.Left)} ?? {ExprToString(coal.Right)}",
+			ObjectLiteralExpression obj => "{" + string.Join(", ", obj.Properties.Select(p => $"{p.Key}: {ExprToString(p.Value)}")) + "}",
+			ArrayLiteralExpression arr => "[" + string.Join(", ", arr.Elements.Select(ExprToString)) + "]",
+			_ => expr.ToString(),
+		};
+	}
+
+	/// <summary>
+	/// Wraps the expression in parentheses if it has lower precedence than binary/unary operators
+	/// (i.e., ternary or coalesce expressions). This ensures that re-parsing the serialized string
+	/// produces the same AST.
+	/// </summary>
+	// Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/ternary-coalesce-operators
+	//   Ternary (?) and Coalesce (??) have the lowest operator precedence in Cosmos DB SQL.
+	private static string WrapIfLowPrecedence(SqlExpression expr) =>
+		expr is TernaryExpression or CoalesceExpression
+			? $"({ExprToString(expr)})"
+			: ExprToString(expr);
+
+	private static string SubqueryToString(CosmosSqlQuery sub)
+	{
+		var sb = new System.Text.StringBuilder("SELECT ");
+		if (sub.IsDistinct)
+		{
+			sb.Append("DISTINCT ");
+		}
+
+		if (sub.TopCount.HasValue)
+		{
+			sb.Append($"TOP {sub.TopCount.Value} ");
+		}
+
+		if (sub.IsValueSelect)
+		{
+			sb.Append("VALUE ");
+		}
+
+		if (sub.IsSelectAll)
+		{
+			sb.Append('*');
+		}
+		else
+		{
+			var selectParts = sub.SelectFields.Select(field =>
+			{
+				var expr = field.SqlExpr is not null ? ExprToString(field.SqlExpr) : field.Expression;
+				return field.Alias is not null ? $"{expr} AS {field.Alias}" : expr;
+			});
+			sb.Append(string.Join(", ", selectParts));
+		}
+
+		if (sub.FromSource is not null)
+		{
+			sb.Append($" FROM {sub.FromAlias} IN {sub.FromSource}");
+		}
+		else
+		{
+			sb.Append($" FROM {sub.FromAlias}");
+		}
+
+		if (sub.Joins is { Length: > 0 })
+		{
+			foreach (var join in sub.Joins)
+			{
+				sb.Append($" JOIN {join.Alias} IN {join.SourceAlias}.{join.ArrayField}");
+			}
+		}
+
+		if (sub.WhereExpr is not null)
+		{
+			sb.Append($" WHERE {ExprToString(sub.WhereExpr)}");
+		}
+
+		if (sub.GroupByFields is { Length: > 0 })
+		{
+			sb.Append($" GROUP BY {string.Join(", ", sub.GroupByFields)}");
+		}
+
+		if (sub.HavingExpr is not null)
+		{
+			sb.Append($" HAVING {ExprToString(sub.HavingExpr)}");
+		}
+
+		if (sub.OrderByFields is { Length: > 0 })
+		{
+			var orderByStr = string.Join(", ", sub.OrderByFields.Select(field =>
+				$"{field.Field} {(field.Ascending ? "ASC" : "DESC")}"));
+			sb.Append($" ORDER BY {orderByStr}");
+		}
+
+		if (sub.Offset.HasValue)
+		{
+			sb.Append($" OFFSET {sub.Offset.Value}");
+		}
+
+		if (sub.Limit.HasValue)
+		{
+			sb.Append($" LIMIT {sub.Limit.Value}");
+		}
+
+		return sb.ToString();
+	}
+
+	private static string BinaryOpToString(BinaryOp op) => op switch
+	{
+		BinaryOp.Equal => "=",
+		BinaryOp.NotEqual => "!=",
+		BinaryOp.LessThan => "<",
+		BinaryOp.GreaterThan => ">",
+		BinaryOp.LessThanOrEqual => "<=",
+		BinaryOp.GreaterThanOrEqual => ">=",
+		BinaryOp.And => "AND",
+		BinaryOp.Or => "OR",
+		BinaryOp.Add => "+",
+		BinaryOp.Subtract => "-",
+		BinaryOp.Multiply => "*",
+		BinaryOp.Divide => "/",
+		BinaryOp.Modulo => "%",
+		BinaryOp.Like => "LIKE",
+		BinaryOp.StringConcat => "||",
+		BinaryOp.BitwiseAnd => "&",
+		BinaryOp.BitwiseOr => "|",
+		BinaryOp.BitwiseXor => "^",
+		_ => op.ToString(),
+	};
+
+	private static string UnaryOpToString(UnaryOp op) => op switch
+	{
+		UnaryOp.Not => "NOT",
+		UnaryOp.Negate => "-",
+		UnaryOp.BitwiseNot => "~",
+		_ => op.ToString(),
+	};
+
+	private static JoinClause ParseJoinSource(string alias, string source)
+	{
+		var dotIdx = source.IndexOf('.');
+		if (dotIdx < 0)
+		{
+			return new JoinClause(alias, source, source);
+		}
+
+		return new JoinClause(alias, source[..dotIdx], source[(dotIdx + 1)..]);
+	}
+
+	private static CosmosSqlQuery BuildQuery(
+		bool isDistinct, int? top, bool isValue,
+		SelectField[] fields, string fromAlias, string fromSource,
+		JoinClause[] joins, SqlExpression whereExpr,
+		string[] groupBy, SqlExpression[] groupByExpressions, SqlExpression havingExpr,
+		OrderByField[] orderByFields,
+		int? offset, int? limit, SqlExpression rankExpr = null)
+	{
+		var isSelectAll = fields.Length == 1 && fields[0].Expression == "*";
+		var where = whereExpr != null ? ToWhereExpression(whereExpr) : null;
+		// HAVING always uses SqlExpressionCondition to preserve aggregate function expressions
+		// (ToWhereExpression would decompose AND/OR into AndCondition/OrCondition with string-based
+		// comparison operands, losing the ability to evaluate aggregate functions like COUNT/SUM).
+		var having = havingExpr != null ? new SqlExpressionCondition(havingExpr) : null;
+		var rawHavingExpr = havingExpr;
+
+		// Backward compat: first join, first order by
+		var firstJoin = joins.Length > 0 ? joins[0] : null;
+		OrderByClause legacyOrderBy = null;
+		if (orderByFields is { Length: > 0 })
+		{
+			legacyOrderBy = new OrderByClause(orderByFields[0].Field, orderByFields[0].Ascending);
+		}
+
+		return new CosmosSqlQuery(
+			SelectFields: fields,
+			IsSelectAll: isSelectAll,
+			TopCount: top,
+			FromAlias: fromAlias,
+			Join: firstJoin,
+			Where: where,
+			Offset: offset,
+			Limit: limit,
+			OrderBy: legacyOrderBy,
+			IsDistinct: isDistinct,
+			IsValueSelect: isValue,
+			Joins: joins,
+			OrderByFields: orderByFields,
+			GroupByFields: groupBy,
+			GroupByExpressions: groupByExpressions,
+			Having: having,
+			WhereExpr: whereExpr,
+			HavingExpr: rawHavingExpr,
+			FromSource: fromSource,
+			RankExpression: rankExpr);
+	}
+
+	// Captures tokens inside balanced parentheses as a raw string
+	private static TokenListParser<CosmosSqlToken, string> CaptureBalancedParens()
+	{
+		return input =>
+		{
+			var depth = 0;
+			var startPos = input.Position;
+			var current = input;
+			var parts = new List<string>();
+
+			while (!current.IsAtEnd)
+			{
+				var token = current.ConsumeToken();
+				if (!token.HasValue)
+				{
+					break;
+				}
+
+				if (token.Value.Kind == CosmosSqlToken.OpenParen)
+				{
+					depth++;
+					parts.Add("(");
+					current = token.Remainder;
+				}
+				else if (token.Value.Kind == CosmosSqlToken.CloseParen)
+				{
+					if (depth == 0)
+					{
+						return TokenListParserResult.Value(string.Join(" ", parts), input, current);
+					}
+					depth--;
+					parts.Add(")");
+					current = token.Remainder;
+				}
+				else
+				{
+					parts.Add(token.Value.Span.ToStringValue());
+					current = token.Remainder;
+				}
+			}
+
+			return TokenListParserResult.Value(string.Join(" ", parts), input, current);
+		};
+	}
 }

--- a/src/CosmosDB.InMemoryEmulator/DefaultQueryPlanStrategy.cs
+++ b/src/CosmosDB.InMemoryEmulator/DefaultQueryPlanStrategy.cs
@@ -142,20 +142,18 @@ public sealed class DefaultQueryPlanStrategy : IQueryPlanStrategy
             queryInfo["hasSelectValue"] = true;
         }
 
-        // Suppress SDK pipeline for GROUP BY, multi-aggregate, and VALUE aggregate
-        // queries. Also bypass any query referencing COUNTIF — the SDK pipeline
-        // doesn't recognize COUNTIF and tries to apply its built-in aggregate
-        // accumulator, which expects a {payload: {alias: {item: value}}} envelope
-        // the handler only produces for GROUP BY responses.
-        // Additionally bypass when literal expressions appear alongside aggregates
-        // (e.g. SELECT 42 AS X, COUNT(1) AS N) — the SDK's AggregateQueryPipelineStage
-        // doesn't handle non-aggregate expression fields and crashes with
+        // Suppress SDK pipeline for GROUP BY and any aggregate queries. The SDK's
+        // AggregateQueryPipelineStage expects a {payload: {alias: {item: value}}} envelope
+        // the handler only produces for GROUP BY responses. On non-Windows platforms
+        // (where ServiceInterop is unavailable), this plan drives the SDK pipeline —
+        // if we report aggregates, the SDK enters its aggregate accumulator which
+        // fails because our handler returns pre-computed results directly.
+        // Also bypass COUNTIF (not recognized by SDK pipeline) and literal+aggregate
+        // combinations (e.g. SELECT 42 AS X, COUNT(1) AS N) which crash with
         // "Underlying object does not have an 'payload' field".
         var isGroupByBypass = parsed.GroupByFields is { Length: > 0 };
         var aggregateFieldCount = parsed.SelectFields.Count(f => ContainsAggregate(f.SqlExpr));
-        var isMultiAggregateBypass = !isGroupByBypass && !parsed.IsValueSelect
-            && (aggregateFieldCount > 1 || aggregates.Count > 1);
-        var isValueAggregateBypass = !isGroupByBypass && parsed.IsValueSelect && aggregateFieldCount > 0;
+        var isAggregateBypass = !isGroupByBypass && aggregateFieldCount > 0;
         var isCountIfBypass = !isGroupByBypass
             && parsed.SelectFields.Any(f => ContainsCountIf(f.SqlExpr));
         // Bypass when there are non-aggregate expression fields (literals, function calls)
@@ -165,7 +163,7 @@ public sealed class DefaultQueryPlanStrategy : IQueryPlanStrategy
             && parsed.SelectFields.Any(f => !ContainsAggregate(f.SqlExpr)
                 && f.SqlExpr is not null and not IdentifierExpression and not PropertyAccessExpression);
 
-        if (isGroupByBypass || isMultiAggregateBypass || isValueAggregateBypass || isCountIfBypass || isLiteralWithAggregateBypass)
+        if (isGroupByBypass || isAggregateBypass || isCountIfBypass || isLiteralWithAggregateBypass)
         {
             queryInfo["groupByExpressions"] = new JArray();
             queryInfo["groupByAliases"] = new JArray();

--- a/src/CosmosDB.InMemoryEmulator/DefaultQueryPlanStrategy.cs
+++ b/src/CosmosDB.InMemoryEmulator/DefaultQueryPlanStrategy.cs
@@ -147,6 +147,10 @@ public sealed class DefaultQueryPlanStrategy : IQueryPlanStrategy
         // doesn't recognize COUNTIF and tries to apply its built-in aggregate
         // accumulator, which expects a {payload: {alias: {item: value}}} envelope
         // the handler only produces for GROUP BY responses.
+        // Additionally bypass when literal expressions appear alongside aggregates
+        // (e.g. SELECT 42 AS X, COUNT(1) AS N) — the SDK's AggregateQueryPipelineStage
+        // doesn't handle non-aggregate expression fields and crashes with
+        // "Underlying object does not have an 'payload' field".
         var isGroupByBypass = parsed.GroupByFields is { Length: > 0 };
         var aggregateFieldCount = parsed.SelectFields.Count(f => ContainsAggregate(f.SqlExpr));
         var isMultiAggregateBypass = !isGroupByBypass && !parsed.IsValueSelect
@@ -154,8 +158,14 @@ public sealed class DefaultQueryPlanStrategy : IQueryPlanStrategy
         var isValueAggregateBypass = !isGroupByBypass && parsed.IsValueSelect && aggregateFieldCount > 0;
         var isCountIfBypass = !isGroupByBypass
             && parsed.SelectFields.Any(f => ContainsCountIf(f.SqlExpr));
+        // Bypass when there are non-aggregate expression fields (literals, function calls)
+        // alongside at least one aggregate — the SDK pipeline can't project these.
+        var isLiteralWithAggregateBypass = !isGroupByBypass && !parsed.IsValueSelect
+            && aggregateFieldCount > 0
+            && parsed.SelectFields.Any(f => !ContainsAggregate(f.SqlExpr)
+                && f.SqlExpr is not null and not IdentifierExpression and not PropertyAccessExpression);
 
-        if (isGroupByBypass || isMultiAggregateBypass || isValueAggregateBypass || isCountIfBypass)
+        if (isGroupByBypass || isMultiAggregateBypass || isValueAggregateBypass || isCountIfBypass || isLiteralWithAggregateBypass)
         {
             queryInfo["groupByExpressions"] = new JArray();
             queryInfo["groupByAliases"] = new JArray();

--- a/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
+++ b/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
@@ -4695,13 +4695,13 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                     if (funcName == "SUM")
                     {
                         if (values.Count > 0)
-                            resultObj[outputName] = values.Sum();
+                            resultObj[outputName] = JToken.FromObject(JsonParseHelpers.NormalizeNumericResult(values.Sum()));
                         // else: omit field entirely (undefined) — matches Cosmos DB
                     }
                     else // AVG
                     {
                         if (values.Count > 0)
-                            resultObj[outputName] = values.Average();
+                            resultObj[outputName] = JToken.FromObject(JsonParseHelpers.NormalizeNumericResult(values.Average()));
                     }
                 }
                 else if (funcName is "MIN" or "MAX" && innerArg != null)
@@ -5077,8 +5077,8 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                     }
                     return func.FunctionName switch
                     {
-                        "SUM" => values.Count > 0 ? (object)values.Sum() : UndefinedValue.Instance,
-                        "AVG" => values.Count > 0 ? (object)values.Average() : UndefinedValue.Instance,
+                        "SUM" => values.Count > 0 ? JsonParseHelpers.NormalizeNumericResult(values.Sum()) : UndefinedValue.Instance,
+                        "AVG" => values.Count > 0 ? JsonParseHelpers.NormalizeNumericResult(values.Average()) : UndefinedValue.Instance,
                         _ => 0.0
                     };
                 }
@@ -5414,13 +5414,13 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 if (funcName == "SUM")
                 {
                     if (values.Count > 0)
-                        resultObj[outputName] = values.Sum();
+                        resultObj[outputName] = JToken.FromObject(JsonParseHelpers.NormalizeNumericResult(values.Sum()));
                     // else: omit field entirely (undefined) — matches Cosmos DB
                 }
                 else // AVG
                 {
                     if (values.Count > 0)
-                        resultObj[outputName] = values.Average();
+                        resultObj[outputName] = JToken.FromObject(JsonParseHelpers.NormalizeNumericResult(values.Average()));
                     // else: omit field entirely (undefined)
                 }
             }
@@ -8006,8 +8006,8 @@ internal class InMemoryContainer : Container, IContainerTestSetup
 
         return name switch
         {
-            "SUM" => values.Count > 0 ? values.Sum(v => v.Value<double>()) : (object)UndefinedValue.Instance,
-            "AVG" => values.Count > 0 ? values.Average(v => v.Value<double>()) : (object)UndefinedValue.Instance,
+            "SUM" => values.Count > 0 ? JsonParseHelpers.NormalizeNumericResult(values.Sum(v => v.Value<double>())) : (object)UndefinedValue.Instance,
+            "AVG" => values.Count > 0 ? JsonParseHelpers.NormalizeNumericResult(values.Average(v => v.Value<double>())) : (object)UndefinedValue.Instance,
             "MIN" => AggregateMinMax(values, true),
             "MAX" => AggregateMinMax(values, false),
             _ => null

--- a/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
+++ b/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
@@ -1130,7 +1130,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             if (predicateParsed.Where is not null)
             {
                 var matches = EvaluateWhereExpression(predicateParsed.Where, jObj, predicateParsed.FromAlias,
-                    new Dictionary<string, object>(), null);
+                    new Dictionary<string, object>(), null, treatUndefinedAsNull: true);
                 if (!matches)
                 {
                     throw InMemoryCosmosException.Create("Precondition Failed",
@@ -1614,7 +1614,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             if (predicateParsed.Where is not null)
             {
                 var matches = EvaluateWhereExpression(predicateParsed.Where, jObj, predicateParsed.FromAlias,
-                    new Dictionary<string, object>(), null);
+                    new Dictionary<string, object>(), null, treatUndefinedAsNull: true);
                 if (!matches)
                 {
                     return CreateResponseMessage(HttpStatusCode.PreconditionFailed);
@@ -5543,17 +5543,17 @@ internal class InMemoryContainer : Container, IContainerTestSetup
 
     private static bool EvaluateWhereExpression(
         WhereExpression expression, JObject item, string fromAlias,
-        IDictionary<string, object> parameters, JoinClause join)
+        IDictionary<string, object> parameters, JoinClause join, bool treatUndefinedAsNull = false)
     {
         return expression switch
         {
-            ComparisonCondition c => EvaluateComparison(c, item, fromAlias, parameters),
-            AndCondition a => EvaluateWhereExpression(a.Left, item, fromAlias, parameters, join)
-                              && EvaluateWhereExpression(a.Right, item, fromAlias, parameters, join),
-            OrCondition o => EvaluateWhereExpression(o.Left, item, fromAlias, parameters, join)
-                             || EvaluateWhereExpression(o.Right, item, fromAlias, parameters, join),
-            NotCondition n => !EvaluateWhereExpressionIncludesUndefined(n.Inner, item, fromAlias, parameters, join)
-                              && !EvaluateWhereExpression(n.Inner, item, fromAlias, parameters, join),
+            ComparisonCondition c => EvaluateComparison(c, item, fromAlias, parameters, treatUndefinedAsNull),
+            AndCondition a => EvaluateWhereExpression(a.Left, item, fromAlias, parameters, join, treatUndefinedAsNull)
+                              && EvaluateWhereExpression(a.Right, item, fromAlias, parameters, join, treatUndefinedAsNull),
+            OrCondition o => EvaluateWhereExpression(o.Left, item, fromAlias, parameters, join, treatUndefinedAsNull)
+                             || EvaluateWhereExpression(o.Right, item, fromAlias, parameters, join, treatUndefinedAsNull),
+            NotCondition n => !EvaluateWhereExpressionIncludesUndefined(n.Inner, item, fromAlias, parameters, join, treatUndefinedAsNull)
+                              && !EvaluateWhereExpression(n.Inner, item, fromAlias, parameters, join, treatUndefinedAsNull),
             FunctionCondition f => EvaluateFunction(f, item, fromAlias, parameters),
             ExistsCondition e => EvaluateExists(e, item, fromAlias, parameters, join),
             SqlExpressionCondition s => IsTruthy(EvaluateSqlExpression(s.Expression, item, fromAlias, parameters)),
@@ -5562,10 +5562,20 @@ internal class InMemoryContainer : Container, IContainerTestSetup
     }
 
     private static bool EvaluateComparison(
-        ComparisonCondition comparison, JObject item, string fromAlias, IDictionary<string, object> parameters)
+        ComparisonCondition comparison, JObject item, string fromAlias, IDictionary<string, object> parameters,
+        bool treatUndefinedAsNull = false)
     {
         var leftValue = ResolveValue(comparison.Left, item, fromAlias, parameters);
         var rightValue = ResolveValue(comparison.Right, item, fromAlias, parameters);
+
+        // Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update#filter-predicate
+        //   In FilterPredicate context, missing properties are treated as null.
+        if (treatUndefinedAsNull)
+        {
+            if (leftValue is UndefinedValue) leftValue = null;
+            if (rightValue is UndefinedValue) rightValue = null;
+        }
+
         if (leftValue is UndefinedValue || rightValue is UndefinedValue)
             return false;
         return comparison.Operator switch
@@ -5587,19 +5597,19 @@ internal class InMemoryContainer : Container, IContainerTestSetup
     /// </summary>
     private static bool EvaluateWhereExpressionIncludesUndefined(
         WhereExpression expression, JObject item, string fromAlias,
-        IDictionary<string, object> parameters, JoinClause join)
+        IDictionary<string, object> parameters, JoinClause join, bool treatUndefinedAsNull = false)
     {
         return expression switch
         {
-            ComparisonCondition c => ComparisonIncludesUndefined(c, item, fromAlias, parameters),
+            ComparisonCondition c => ComparisonIncludesUndefined(c, item, fromAlias, parameters, treatUndefinedAsNull),
             AndCondition a =>
-                EvaluateWhereExpressionIncludesUndefined(a.Left, item, fromAlias, parameters, join) ||
-                EvaluateWhereExpressionIncludesUndefined(a.Right, item, fromAlias, parameters, join),
+                EvaluateWhereExpressionIncludesUndefined(a.Left, item, fromAlias, parameters, join, treatUndefinedAsNull) ||
+                EvaluateWhereExpressionIncludesUndefined(a.Right, item, fromAlias, parameters, join, treatUndefinedAsNull),
             OrCondition o =>
-                EvaluateWhereExpressionIncludesUndefined(o.Left, item, fromAlias, parameters, join) ||
-                EvaluateWhereExpressionIncludesUndefined(o.Right, item, fromAlias, parameters, join),
+                EvaluateWhereExpressionIncludesUndefined(o.Left, item, fromAlias, parameters, join, treatUndefinedAsNull) ||
+                EvaluateWhereExpressionIncludesUndefined(o.Right, item, fromAlias, parameters, join, treatUndefinedAsNull),
             NotCondition n =>
-                EvaluateWhereExpressionIncludesUndefined(n.Inner, item, fromAlias, parameters, join),
+                EvaluateWhereExpressionIncludesUndefined(n.Inner, item, fromAlias, parameters, join, treatUndefinedAsNull),
             SqlExpressionCondition s =>
                 EvaluateSqlExpression(s.Expression, item, fromAlias, parameters) is UndefinedValue,
             _ => false,
@@ -5609,12 +5619,22 @@ internal class InMemoryContainer : Container, IContainerTestSetup
     /// <summary>
     /// Checks if a comparison involves undefined semantics. For most operators, only
     /// UndefinedValue counts. For LIKE, null also produces undefined (three-value logic).
+    /// When treatUndefinedAsNull is true, undefined is treated as null (FilterPredicate context).
     /// </summary>
     private static bool ComparisonIncludesUndefined(
-        ComparisonCondition c, JObject item, string fromAlias, IDictionary<string, object> parameters)
+        ComparisonCondition c, JObject item, string fromAlias, IDictionary<string, object> parameters,
+        bool treatUndefinedAsNull = false)
     {
         var left = ResolveValue(c.Left, item, fromAlias, parameters);
         var right = ResolveValue(c.Right, item, fromAlias, parameters);
+
+        // In FilterPredicate context, undefined is treated as null — not "undefined"
+        if (treatUndefinedAsNull)
+        {
+            if (left is UndefinedValue) left = null;
+            if (right is UndefinedValue) right = null;
+        }
+
         if (left is UndefinedValue || right is UndefinedValue)
             return true;
         // LIKE with null operand(s) produces undefined per three-value logic

--- a/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
+++ b/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
@@ -5352,6 +5352,20 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 if (val is not null and not UndefinedValue)
                     resultObj[outputName] = val is JToken jt ? jt.DeepClone() : JToken.FromObject(val);
             }
+            // Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/select
+            //   "The SELECT clause supports arbitrary expressions including literal values."
+            // Handle non-aggregate, non-trivial expressions (literals, function calls, etc.)
+            // by evaluating the SqlExpr directly instead of treating as a property path.
+            else if (field.SqlExpr is not null and not IdentifierExpression)
+            {
+                var jObj = items.Count > 0 ? JsonParseHelpers.ParseJson(items[0]) : new JObject();
+                var val = EvaluateSqlExpression(field.SqlExpr, jObj, parsed.FromAlias,
+                    parameters ?? new Dictionary<string, object>());
+                if (val is not null and not UndefinedValue)
+                    resultObj[outputName] = val is JToken jt ? jt.DeepClone() : JToken.FromObject(val);
+                else if (val is null)
+                    resultObj[outputName] = JValue.CreateNull();
+            }
             else
             {
                 var path = field.Expression;

--- a/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
+++ b/src/CosmosDB.InMemoryEmulator/InMemoryContainer.cs
@@ -74,6 +74,11 @@ internal class InMemoryContainer : Container, IContainerTestSetup
     private readonly ConcurrentDictionary<(string Id, string PartitionKey), string> _items = new();
     private readonly ConcurrentDictionary<(string Id, string PartitionKey), string> _etags = new();
     private readonly ConcurrentDictionary<(string Id, string PartitionKey), DateTimeOffset> _timestamps = new();
+    // Ref: Observed behavior on Windows Cosmos DB Emulator — documents return in
+    //   insertion order when no ORDER BY is applied. Maintains creation-time ordering
+    //   so GetAllItemsForPartition can enumerate deterministically.
+    private readonly List<(string Id, string PartitionKey)> _insertionOrder = new();
+    private readonly object _insertionOrderLock = new();
     private readonly List<(DateTimeOffset Timestamp, string Id, string PartitionKey, string Json, bool IsDelete)> _changeFeed = new();
     private readonly object _changeFeedLock = new();
     private long _changeFeedLsnCounter;
@@ -357,6 +362,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
         _items.Clear();
         _etags.Clear();
         _timestamps.Clear();
+        lock (_insertionOrderLock) { _insertionOrder.Clear(); }
         lock (_changeFeedLock) { _changeFeed.Clear(); }
     }
 
@@ -402,9 +408,11 @@ internal class InMemoryContainer : Container, IContainerTestSetup
     /// </summary>
     public string ExportState()
     {
-        var items = _items
-            .Where(kvp => !IsExpired(kvp.Key))
-            .Select(kvp => JsonParseHelpers.ParseJson(kvp.Value)).ToList();
+        List<(string Id, string PartitionKey)> orderedKeys;
+        lock (_insertionOrderLock) { orderedKeys = _insertionOrder.ToList(); }
+        var items = orderedKeys
+            .Where(key => _items.ContainsKey(key) && !IsExpired(key))
+            .Select(key => JsonParseHelpers.ParseJson(_items[key])).ToList();
         var state = new JObject { ["items"] = new JArray(items) };
         return state.ToString(Formatting.Indented);
     }
@@ -437,6 +445,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             _etags[key] = importEtag;
             _timestamps[key] = DateTimeOffset.UtcNow;
             _items[key] = EnrichWithSystemProperties(itemJson, importEtag, _timestamps[key]);
+            lock (_insertionOrderLock) { _insertionOrder.Add(key); }
         }
     }
 
@@ -489,6 +498,25 @@ internal class InMemoryContainer : Container, IContainerTestSetup
         _etags.Clear();
         _timestamps.Clear();
         _itemLocks.Clear();
+        lock (_insertionOrderLock) { _insertionOrder.Clear(); }
+
+        // Rebuild insertion order from the change feed replay sequence.
+        // Track which keys were first created (not deleted) to preserve original insertion order.
+        var insertionOrderKeys = new List<(string Id, string PartitionKey)>();
+        foreach (var entry in feedSnapshot)
+        {
+            if (entry.IsDelete && entry.Json.Contains("\"_ttlEviction\":true", StringComparison.Ordinal))
+                continue;
+            var entryKey = (entry.Id, entry.PartitionKey);
+            if (entry.IsDelete)
+            {
+                insertionOrderKeys.Remove(entryKey);
+            }
+            else if (!insertionOrderKeys.Contains(entryKey))
+            {
+                insertionOrderKeys.Add(entryKey);
+            }
+        }
 
         foreach (var kvp in lastPerKey)
         {
@@ -499,6 +527,15 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             _items[key] = EnrichWithSystemProperties(kvp.Value.Json, etag, pointInTime);
             _etags[key] = etag;
             _timestamps[key] = pointInTime;
+        }
+
+        lock (_insertionOrderLock)
+        {
+            foreach (var key in insertionOrderKeys)
+            {
+                if (_items.ContainsKey(key))
+                    _insertionOrder.Add(key);
+            }
         }
     }
 
@@ -738,6 +775,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             }
 
             TrackBatchWrite(key);
+            lock (_insertionOrderLock) { _insertionOrder.Add(key); }
             var etag = GenerateETag();
             _etags[key] = etag;
             _timestamps[key] = DateTimeOffset.UtcNow;
@@ -773,6 +811,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 _items.TryRemove(key, out _);
                 _etags.TryRemove(key, out _);
                 _timestamps.TryRemove(key, out _);
+                lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
                 throw;
             }
         }
@@ -867,6 +906,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             }
 
             TrackBatchWrite(key);
+            if (!existed) { lock (_insertionOrderLock) { _insertionOrder.Add(key); } }
 
             try
             {
@@ -893,6 +933,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                     _items.TryRemove(key, out _);
                     _etags.TryRemove(key, out _);
                     _timestamps.TryRemove(key, out _);
+                    lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
                 }
                 throw;
             }
@@ -1045,6 +1086,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             _items.TryRemove(key, out _);
             _etags.TryRemove(key, out _);
             _timestamps.TryRemove(key, out _);
+            lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
 
             TrackBatchWrite(key);
             try
@@ -1057,6 +1099,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 _items[key] = existingJson;
                 if (previousEtag is not null) _etags[key] = previousEtag;
                 if (previousTimestamp.HasValue) _timestamps[key] = previousTimestamp.Value;
+                lock (_insertionOrderLock) { _insertionOrder.Add(key); }
                 throw;
             }
 
@@ -1236,6 +1279,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             }
 
             TrackBatchWrite(key);
+            lock (_insertionOrderLock) { _insertionOrder.Add(key); }
             var etag = GenerateETag();
             _etags[key] = etag;
             _timestamps[key] = DateTimeOffset.UtcNow;
@@ -1252,6 +1296,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 _items.TryRemove(key, out _);
                 _etags.TryRemove(key, out _);
                 _timestamps.TryRemove(key, out _);
+                lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
                 throw;
             }
 
@@ -1360,6 +1405,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             }
 
             TrackBatchWrite(key);
+            if (!existed) { lock (_insertionOrderLock) { _insertionOrder.Add(key); } }
             try
             {
                 ExecutePostTriggers(requestOptions, JsonParseHelpers.ParseJson(enrichedJson), "Upsert");
@@ -1378,6 +1424,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                     _items.TryRemove(key, out _);
                     _etags.TryRemove(key, out _);
                     _timestamps.TryRemove(key, out _);
+                    lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
                 }
                 throw;
             }
@@ -1525,6 +1572,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             _items.TryRemove(key, out _);
             _etags.TryRemove(key, out _);
             _timestamps.TryRemove(key, out _);
+            lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
 
             TrackBatchWrite(key);
             try
@@ -1537,6 +1585,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 _items[key] = existingJson;
                 if (previousEtag is not null) _etags[key] = previousEtag;
                 if (previousTimestamp.HasValue) _timestamps[key] = previousTimestamp.Value;
+                lock (_insertionOrderLock) { _insertionOrder.Add(key); }
                 throw;
             }
 
@@ -2364,6 +2413,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
         _items.Clear();
         _etags.Clear();
         _timestamps.Clear();
+        lock (_insertionOrderLock) { _insertionOrder.Clear(); }
         lock (_changeFeedLock) { _changeFeed.Clear(); }
         _storedProcedures.Clear();
         _userDefinedFunctions.Clear();
@@ -2386,6 +2436,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
         _items.Clear();
         _etags.Clear();
         _timestamps.Clear();
+        lock (_insertionOrderLock) { _insertionOrder.Clear(); }
         lock (_changeFeedLock) { _changeFeed.Clear(); }
         _storedProcedures.Clear();
         _userDefinedFunctions.Clear();
@@ -2449,6 +2500,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
             _items.TryRemove(key, out _);
             _etags.TryRemove(key, out _);
             _timestamps.TryRemove(key, out _);
+            lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
             RecordDeleteTombstone(key.Id, pk, partitionKey);
         }
         return Task.FromResult(CreateResponseMessage(HttpStatusCode.OK));
@@ -3408,6 +3460,7 @@ internal class InMemoryContainer : Container, IContainerTestSetup
         _items.TryRemove(key, out _);
         _etags.TryRemove(key, out _);
         _timestamps.TryRemove(key, out _);
+        lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
 
         // Record a delete tombstone in the change feed so consumers see TTL evictions
         RecordDeleteTombstone(key.Id, key.PartitionKey, isTtlEviction: true);
@@ -3467,6 +3520,27 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 _items.TryRemove(key, out _);
                 _etags.TryRemove(key, out _);
                 _timestamps.TryRemove(key, out _);
+                lock (_insertionOrderLock) { _insertionOrder.Remove(key); }
+            }
+        }
+
+        // Restore insertion order for keys that were newly added during the batch
+        // but didn't exist in the snapshot — they need to be removed from insertion order.
+        // Keys that existed in the snapshot should already be in insertion order.
+        lock (_insertionOrderLock)
+        {
+            foreach (var key in touchedKeys)
+            {
+                if (!itemsSnapshot.ContainsKey(key))
+                {
+                    // Already removed above
+                }
+                else if (!_insertionOrder.Contains(key))
+                {
+                    // Item existed in snapshot but is missing from insertion order
+                    // (shouldn't normally happen, but be safe)
+                    _insertionOrder.Add(key);
+                }
             }
         }
 
@@ -4061,8 +4135,16 @@ internal class InMemoryContainer : Container, IContainerTestSetup
     //  Private helpers — Query execution pipeline
     // ═══════════════════════════════════════════════════════════════════════════
 
+    // Ref: Observed behavior on the Windows Cosmos DB Emulator (priority 6):
+    //   Documents returned by queries without ORDER BY are in insertion order.
     private IEnumerable<string> GetAllItemsForPartition(QueryRequestOptions requestOptions)
     {
+        List<(string Id, string PartitionKey)> orderedKeys;
+        lock (_insertionOrderLock)
+        {
+            orderedKeys = _insertionOrder.ToList();
+        }
+
         if (requestOptions?.PartitionKey is not null
             && requestOptions.PartitionKey != PartitionKey.None)
         {
@@ -4076,15 +4158,19 @@ internal class InMemoryContainer : Container, IContainerTestSetup
                 if (queryComponents > 0 && queryComponents < PartitionKeyPaths.Count)
                 {
                     var prefix = pk + "|";
-                    return _items
-                        .Where(kvp => (kvp.Key.PartitionKey?.StartsWith(prefix, StringComparison.Ordinal) ?? false) && !IsExpired(kvp.Key))
-                        .Select(kvp => kvp.Value);
+                    return orderedKeys
+                        .Where(key => (key.PartitionKey?.StartsWith(prefix, StringComparison.Ordinal) ?? false) && !IsExpired(key) && _items.ContainsKey(key))
+                        .Select(key => _items[key]);
                 }
             }
 
-            return _items.Where(kvp => kvp.Key.PartitionKey == pk && !IsExpired(kvp.Key)).Select(kvp => kvp.Value);
+            return orderedKeys
+                .Where(key => key.PartitionKey == pk && !IsExpired(key) && _items.ContainsKey(key))
+                .Select(key => _items[key]);
         }
-        return _items.Where(kvp => !IsExpired(kvp.Key)).Select(kvp => kvp.Value);
+        return orderedKeys
+            .Where(key => !IsExpired(key) && _items.ContainsKey(key))
+            .Select(key => _items[key]);
     }
 
     private static int CountPartitionKeyComponents(PartitionKey partitionKey)

--- a/src/CosmosDB.InMemoryEmulator/JsonParseHelpers.cs
+++ b/src/CosmosDB.InMemoryEmulator/JsonParseHelpers.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -11,7 +12,18 @@ internal static class JsonParseHelpers
         {
             DateParseHandling = DateParseHandling.None
         };
-        return JObject.Load(reader);
+        var obj = JObject.Load(reader);
+
+        // Normalize numeric values to match Cosmos DB's minimal JSON representation.
+        // Cosmos DB stores numbers without trailing zeros: 1500.0 → 1500, 100.50 → 100.5.
+        // We serialize with a custom writer that strips trailing zeros, then reparse so the
+        // internal JValue representations have the correct scale for subsequent ToString() calls.
+        var normalized = ToCosmosJson(obj);
+        using var reader2 = new JsonTextReader(new StringReader(normalized))
+        {
+            DateParseHandling = DateParseHandling.None
+        };
+        return JObject.Load(reader2);
     }
 
     internal static JToken ParseJsonToken(string json)
@@ -20,6 +32,90 @@ internal static class JsonParseHelpers
         {
             DateParseHandling = DateParseHandling.None
         };
-        return JToken.Load(reader);
+        var token = JToken.Load(reader);
+
+        if (token is JObject or JArray)
+        {
+            var normalized = ToCosmosJson(token);
+            using var reader2 = new JsonTextReader(new StringReader(normalized))
+            {
+                DateParseHandling = DateParseHandling.None
+            };
+            return JToken.Load(reader2);
+        }
+
+        return token;
+    }
+
+    /// <summary>
+    /// Serializes a JToken to JSON using Cosmos DB's minimal numeric representation.
+    /// Whole numbers are written without .0, trailing fractional zeros are stripped.
+    /// </summary>
+    /// <remarks>
+    /// Ref: https://learn.microsoft.com/en-us/rest/api/cosmos-db/documents
+    ///   Cosmos DB uses JSON (RFC 8259) for document storage. JSON numbers have no
+    ///   concept of "scale" — 1500.0 and 1500 are the same value. Cosmos normalizes
+    ///   to the minimal representation on storage.
+    /// </remarks>
+    internal static string ToCosmosJson(JToken token)
+    {
+        using var sw = new StringWriter();
+        using var writer = new CosmosJsonWriter(sw) { Formatting = Formatting.None };
+        token.WriteTo(writer);
+        return sw.ToString();
+    }
+
+    /// <summary>
+    /// Normalizes a numeric aggregate result to match Cosmos DB's output format.
+    /// Whole-number results are returned as long; fractional results as double
+    /// with trailing zeros stripped.
+    /// </summary>
+    internal static object NormalizeNumericResult(double value)
+    {
+        // Ref: Observed Cosmos DB emulator behavior — SUM/AVG of whole numbers
+        // returns integers (no .0), e.g. SUM(375, 375) = 750 not 750.0.
+        // We use strict < for MaxValue because (double)long.MaxValue rounds up to 2^63,
+        // which overflows the long cast on .NET 8 (wraps to long.MinValue).
+        if (value == Math.Truncate(value) && value >= long.MinValue && value < (double)long.MaxValue)
+            return (long)value;
+        return value;
+    }
+
+    /// <summary>
+    /// Custom JsonTextWriter that writes numbers in their minimal JSON representation,
+    /// matching how Cosmos DB stores numeric values.
+    /// </summary>
+    private sealed class CosmosJsonWriter : JsonTextWriter
+    {
+        public CosmosJsonWriter(TextWriter writer) : base(writer) { }
+
+        public override void WriteValue(decimal value)
+        {
+            if (value == decimal.Truncate(value) && value >= long.MinValue && value <= long.MaxValue)
+            {
+                // Whole number — write as integer (no .0 suffix)
+                WriteValue((long)value);
+            }
+            else
+            {
+                // Fractional — write minimal representation (strip trailing zeros)
+                WriteRawValue(value.ToString("G29", CultureInfo.InvariantCulture));
+            }
+        }
+
+        public override void WriteValue(double value)
+        {
+            // Strict < for MaxValue: (double)long.MaxValue rounds up to 2^63 which
+            // cannot be cast to long without overflow on .NET 8.
+            if (value == Math.Truncate(value) && value >= long.MinValue && value < (double)long.MaxValue)
+            {
+                // Whole number — write as integer
+                WriteValue((long)value);
+            }
+            else
+            {
+                base.WriteValue(value);
+            }
+        }
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
 	<!-- Shared NuGet package metadata for all source (packable) projects -->
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>4.0.18</Version>
+		<Version>4.0.19</Version>
 		<Authors>lemonlion</Authors>
 		<Copyright>Copyright (c) 2026 lemonlion</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
 	<!-- Shared NuGet package metadata for all source (packable) projects -->
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>4.0.21</Version>
+		<Version>4.0.20</Version>
 		<Authors>lemonlion</Authors>
 		<Copyright>Copyright (c) 2026 lemonlion</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
 	<!-- Shared NuGet package metadata for all source (packable) projects -->
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>4.0.20</Version>
+		<Version>4.0.21</Version>
 		<Authors>lemonlion</Authors>
 		<Copyright>Copyright (c) 2026 lemonlion</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
 	<!-- Shared NuGet package metadata for all source (packable) projects -->
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>4.0.17</Version>
+		<Version>4.0.18</Version>
 		<Authors>lemonlion</Authors>
 		<Copyright>Copyright (c) 2026 lemonlion</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
 	<!-- Shared NuGet package metadata for all source (packable) projects -->
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>4.0.19</Version>
+		<Version>4.0.20</Version>
 		<Authors>lemonlion</Authors>
 		<Copyright>Copyright (c) 2026 lemonlion</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/DecimalScaleTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/DecimalScaleTests.cs
@@ -1,0 +1,324 @@
+using AwesomeAssertions;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Reproduction tests for decimal scale inconsistencies (GitHub issue #75).
+///
+/// Bug 1 - Round-trip scale modification (cross-platform, Windows AND Linux):
+///   Whole numbers gain a trailing .0 (e.g., 1500m becomes 1500.0m).
+///   Trailing zeros are stripped from fractional values (e.g., 100.50m becomes 100.5m).
+///
+/// Bug 2 - SUM aggregate platform inconsistency (Linux-specific):
+///   On Windows, SUM(375, 375) returns 750m (ToString => "750").
+///   On Linux, SUM(375, 375) returns 750.0m (ToString => "750.0").
+///
+/// Parity-validated: runs against both FakeCosmosHandler (in-memory) and real emulator.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public class DecimalScaleTests(EmulatorSession session, ITestOutputHelper output) : IAsyncLifetime
+{
+    private readonly ITestContainerFixture _fixture = TestFixtureFactory.Create(session);
+    private Container _container = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _container = await _fixture.CreateContainerAsync("test-decimal-scale", "/partitionKey");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Bug 1: Round-trip scale modification (cross-platform)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    [InlineData(42, "42")]
+    [InlineData(750, "750")]
+    [InlineData(1500, "1500")]
+    [InlineData(999999, "999999")]
+    public async Task RoundTrip_WholeNumber_ShouldNotGainDecimalPlaces(int inputValue, string expectedToString)
+    {
+        var id = Guid.NewGuid().ToString();
+        var document = new DecimalDoc { Id = id, PartitionKey = "pk", Amount = inputValue };
+
+        await _container.CreateItemAsync(document, new PartitionKey("pk"));
+        var response = await _container.ReadItemAsync<DecimalDoc>(id, new PartitionKey("pk"));
+
+        output.WriteLine($"Input: {inputValue}m -> Round-trip: {response.Resource.Amount}m (ToString: \"{response.Resource.Amount}\")");
+
+        response.Resource.Amount.Should().Be(inputValue, "the arithmetic value must be preserved");
+        response.Resource.Amount.ToString().Should().Be(expectedToString,
+            $"whole number {inputValue}m should not gain trailing decimal places after round-trip");
+    }
+
+    [Theory]
+    [InlineData("100.50", "100.50")]
+    [InlineData("25.00", "25.00")]
+    [InlineData("0.10", "0.10")]
+    [InlineData("1.00", "1.00")]
+    [InlineData("999.990", "999.990")]
+    public async Task RoundTrip_TrailingZeros_ShouldBePreserved(string inputValue, string expectedToString)
+    {
+        var id = Guid.NewGuid().ToString();
+        var amount = decimal.Parse(inputValue);
+        var document = new DecimalDoc { Id = id, PartitionKey = "pk", Amount = amount };
+
+        await _container.CreateItemAsync(document, new PartitionKey("pk"));
+        var response = await _container.ReadItemAsync<DecimalDoc>(id, new PartitionKey("pk"));
+
+        output.WriteLine($"Input: {inputValue} -> Round-trip: {response.Resource.Amount} (ToString: \"{response.Resource.Amount}\")");
+
+        response.Resource.Amount.Should().Be(amount, "the arithmetic value must be preserved");
+        response.Resource.Amount.ToString().Should().Be(expectedToString,
+            $"decimal {inputValue} should preserve trailing zeros after round-trip (scale must be maintained)");
+    }
+
+    [Theory]
+    [InlineData("0.01", "0.01")]
+    [InlineData("123.456", "123.456")]
+    [InlineData("999.99", "999.99")]
+    [InlineData("0.001", "0.001")]
+    public async Task RoundTrip_SignificantFractionalDigits_ShouldBePreserved(string inputValue, string expectedToString)
+    {
+        var id = Guid.NewGuid().ToString();
+        var amount = decimal.Parse(inputValue);
+        var document = new DecimalDoc { Id = id, PartitionKey = "pk", Amount = amount };
+
+        await _container.CreateItemAsync(document, new PartitionKey("pk"));
+        var response = await _container.ReadItemAsync<DecimalDoc>(id, new PartitionKey("pk"));
+
+        output.WriteLine($"Input: {inputValue} -> Round-trip: {response.Resource.Amount} (ToString: \"{response.Resource.Amount}\")");
+
+        response.Resource.Amount.Should().Be(amount, "the arithmetic value must be preserved");
+        response.Resource.Amount.ToString().Should().Be(expectedToString,
+            $"decimal {inputValue} should preserve all significant digits after round-trip");
+    }
+
+    [Fact]
+    public async Task RoundTrip_MultipleProperties_ShouldAllPreserveScale()
+    {
+        var id = Guid.NewGuid().ToString();
+        var document = new MultiDecimalDoc
+        {
+            Id = id,
+            PartitionKey = "pk",
+            WholeNumber = 1500m,
+            WithTrailingZero = 100.50m,
+            PureZero = 0m,
+            SmallFraction = 0.01m
+        };
+
+        await _container.CreateItemAsync(document, new PartitionKey("pk"));
+        var response = await _container.ReadItemAsync<MultiDecimalDoc>(id, new PartitionKey("pk"));
+
+        output.WriteLine($"WholeNumber: {document.WholeNumber} -> {response.Resource.WholeNumber}");
+        output.WriteLine($"WithTrailingZero: {document.WithTrailingZero} -> {response.Resource.WithTrailingZero}");
+        output.WriteLine($"PureZero: {document.PureZero} -> {response.Resource.PureZero}");
+        output.WriteLine($"SmallFraction: {document.SmallFraction} -> {response.Resource.SmallFraction}");
+
+        response.Resource.WholeNumber.ToString().Should().Be("1500", "whole number should not gain .0");
+        response.Resource.WithTrailingZero.ToString().Should().Be("100.50", "trailing zero should be preserved");
+        response.Resource.PureZero.ToString().Should().Be("0", "zero should remain 0 without .0");
+        response.Resource.SmallFraction.ToString().Should().Be("0.01", "significant fractional digits should be preserved");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Bug 2: SUM aggregate platform inconsistency (Linux-specific)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SumAggregate_TwoWholeNumbers_ShouldReturnWholeNumber()
+    {
+        await SeedDocuments(("a", 375m), ("b", 375m));
+
+        var result = await RunSumQuery();
+
+        output.WriteLine($"SUM(375 + 375) = {result}, ToString: \"{result}\"");
+
+        result.Should().Be(750m, "arithmetic must be correct");
+        result.ToString().Should().Be("750",
+            "SUM of whole numbers should return a whole number without trailing .0");
+    }
+
+    [Fact]
+    public async Task SumAggregate_MultipleWholeNumbers_ShouldReturnWholeNumber()
+    {
+        await SeedDocuments(("a", 100m), ("b", 200m), ("c", 300m), ("d", 400m), ("e", 500m));
+
+        var result = await RunSumQuery();
+
+        output.WriteLine($"SUM(100+200+300+400+500) = {result}, ToString: \"{result}\"");
+
+        result.Should().Be(1500m, "arithmetic must be correct");
+        result.ToString().Should().Be("1500",
+            "SUM of multiple whole numbers should return a whole number");
+    }
+
+    [Fact]
+    public async Task SumAggregate_SingleWholeNumber_ShouldReturnWholeNumber()
+    {
+        await SeedDocuments(("a", 1500m));
+
+        var result = await RunSumQuery();
+
+        output.WriteLine($"SUM(1500) = {result}, ToString: \"{result}\"");
+
+        result.Should().Be(1500m, "arithmetic must be correct");
+        result.ToString().Should().Be("1500",
+            "SUM of a single whole number should not gain decimal places");
+    }
+
+    [Fact]
+    public async Task SumAggregate_FractionalNumbers_ShouldPreserveMinimumScale()
+    {
+        await SeedDocuments(("a", 25.50m), ("b", 25.00m));
+
+        var result = await RunSumQuery();
+
+        output.WriteLine($"SUM(25.50 + 25.00) = {result}, ToString: \"{result}\"");
+
+        result.Should().Be(50.5m, "arithmetic must be correct");
+        result.ToString().Should().BeOneOf("50.5", "50.50",
+            "SUM of fractional numbers should not add unexpected trailing zeros");
+    }
+
+    [Fact]
+    public async Task SumAggregate_MixedWholeAndFractional_ShouldReturnFractionalResult()
+    {
+        await SeedDocuments(("a", 100m), ("b", 50.25m));
+
+        var result = await RunSumQuery();
+
+        output.WriteLine($"SUM(100 + 50.25) = {result}, ToString: \"{result}\"");
+
+        result.Should().Be(150.25m, "arithmetic must be correct");
+        result.ToString().Should().Be("150.25",
+            "SUM with a fractional addend should produce a fractional result");
+    }
+
+    [Fact]
+    public async Task SumAggregate_ResultUsedInStringInterpolation_ShouldProduceConsistentOutput()
+    {
+        await SeedDocuments(("a", 750m), ("b", 750m));
+
+        var transactionDebitTotal = await RunSumQuery();
+        var clearingFileDebitTotal = 1650m;
+
+        var message = $"Clearing file debit total: {clearingFileDebitTotal}, transaction debit total: {transactionDebitTotal}";
+
+        output.WriteLine($"Message: \"{message}\"");
+
+        message.Should().Be("Clearing file debit total: 1650, transaction debit total: 1500",
+            "string interpolation of SUM result should produce platform-consistent output without trailing .0");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Compound effect: LINQ Sum on round-tripped values
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task LinqSum_OnRoundTrippedWholeNumbers_ShouldReturnWholeNumber()
+    {
+        await SeedDocuments(("a", 750m), ("b", 750m));
+
+        var query = _container.GetItemQueryIterator<DecimalDoc>(
+            new QueryDefinition("SELECT * FROM c WHERE c.partitionKey = 'pk'"));
+
+        var results = new List<DecimalDoc>();
+        while (query.HasMoreResults)
+        {
+            var feed = await query.ReadNextAsync();
+            results.AddRange(feed);
+        }
+
+        var sum = results.Sum(r => r.Amount);
+
+        output.WriteLine($"Values after round-trip: {string.Join(", ", results.Select(r => $"\"{r.Amount}\""))}");
+        output.WriteLine($"LINQ Sum: {sum}, ToString: \"{sum}\"");
+
+        sum.Should().Be(1500m, "arithmetic must be correct");
+        sum.ToString().Should().Be("1500",
+            "LINQ Sum of whole-number decimals should not produce trailing decimal places");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Helpers
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    private async Task SeedDocuments(params (string id, decimal value)[] items)
+    {
+        foreach (var (id, value) in items)
+        {
+            await _container.CreateItemAsync(
+                new DecimalDoc { Id = id, PartitionKey = "pk", Amount = value },
+                new PartitionKey("pk"));
+        }
+    }
+
+    private async Task<decimal> RunSumQuery()
+    {
+        var query = _container.GetItemQueryIterator<SumResult>(
+            new QueryDefinition("SELECT SUM(c.amount) as total FROM c WHERE c.partitionKey = 'pk'"));
+
+        while (query.HasMoreResults)
+        {
+            var feed = await query.ReadNextAsync();
+            var result = feed.FirstOrDefault();
+            if (result is not null) return result.Total;
+        }
+
+        throw new InvalidOperationException("SUM query returned no results");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Models
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    private class DecimalDoc
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonProperty("partitionKey")]
+        public string PartitionKey { get; set; } = string.Empty;
+
+        [JsonProperty("amount")]
+        public decimal Amount { get; set; }
+    }
+
+    private class MultiDecimalDoc
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonProperty("partitionKey")]
+        public string PartitionKey { get; set; } = string.Empty;
+
+        [JsonProperty("wholeNumber")]
+        public decimal WholeNumber { get; set; }
+
+        [JsonProperty("withTrailingZero")]
+        public decimal WithTrailingZero { get; set; }
+
+        [JsonProperty("pureZero")]
+        public decimal PureZero { get; set; }
+
+        [JsonProperty("smallFraction")]
+        public decimal SmallFraction { get; set; }
+    }
+
+    private class SumResult
+    {
+        [JsonProperty("total")]
+        public decimal Total { get; set; }
+    }
+}

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/DecimalScaleTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/DecimalScaleTests.cs
@@ -60,13 +60,17 @@ public class DecimalScaleTests(EmulatorSession session, ITestOutputHelper output
             $"whole number {inputValue}m should not gain trailing decimal places after round-trip");
     }
 
+    // Ref: Observed behavior on both Windows and Linux Cosmos DB emulators.
+    //   Cosmos DB stores numbers in JSON as raw numeric literals. Trailing zeros
+    //   (which are JSON-insignificant) are stripped on round-trip: 100.50 → 100.5,
+    //   25.00 → 25, etc. This is correct Cosmos behavior, not a bug.
     [Theory]
-    [InlineData("100.50", "100.50")]
-    [InlineData("25.00", "25.00")]
-    [InlineData("0.10", "0.10")]
-    [InlineData("1.00", "1.00")]
-    [InlineData("999.990", "999.990")]
-    public async Task RoundTrip_TrailingZeros_ShouldBePreserved(string inputValue, string expectedToString)
+    [InlineData("100.50", "100.5")]
+    [InlineData("25.00", "25")]
+    [InlineData("0.10", "0.1")]
+    [InlineData("1.00", "1")]
+    [InlineData("999.990", "999.99")]
+    public async Task RoundTrip_TrailingZeros_ShouldBeStripped(string inputValue, string expectedToString)
     {
         var id = Guid.NewGuid().ToString();
         var amount = decimal.Parse(inputValue);
@@ -79,7 +83,7 @@ public class DecimalScaleTests(EmulatorSession session, ITestOutputHelper output
 
         response.Resource.Amount.Should().Be(amount, "the arithmetic value must be preserved");
         response.Resource.Amount.ToString().Should().Be(expectedToString,
-            $"decimal {inputValue} should preserve trailing zeros after round-trip (scale must be maintained)");
+            $"decimal {inputValue} should have trailing zeros stripped after round-trip (Cosmos stores minimal JSON representation)");
     }
 
     [Theory]
@@ -126,7 +130,7 @@ public class DecimalScaleTests(EmulatorSession session, ITestOutputHelper output
         output.WriteLine($"SmallFraction: {document.SmallFraction} -> {response.Resource.SmallFraction}");
 
         response.Resource.WholeNumber.ToString().Should().Be("1500", "whole number should not gain .0");
-        response.Resource.WithTrailingZero.ToString().Should().Be("100.50", "trailing zero should be preserved");
+        response.Resource.WithTrailingZero.ToString().Should().Be("100.5", "trailing zero should be stripped (Cosmos stores minimal JSON)");
         response.Resource.PureZero.ToString().Should().Be("0", "zero should remain 0 without .0");
         response.Resource.SmallFraction.ToString().Should().Be("0.01", "significant fractional digits should be preserved");
     }
@@ -187,8 +191,8 @@ public class DecimalScaleTests(EmulatorSession session, ITestOutputHelper output
         output.WriteLine($"SUM(25.50 + 25.00) = {result}, ToString: \"{result}\"");
 
         result.Should().Be(50.5m, "arithmetic must be correct");
-        result.ToString().Should().BeOneOf("50.5", "50.50",
-            "SUM of fractional numbers should not add unexpected trailing zeros");
+        result.ToString().Should().Be("50.5",
+            "SUM of fractional numbers should return the minimal representation");
     }
 
     [Fact]

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/FakeCosmosHandlerInsertionOrderHardeningTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/FakeCosmosHandlerInsertionOrderHardeningTests.cs
@@ -1,0 +1,718 @@
+using AwesomeAssertions;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Hardening tests for insertion order behavior in queries without ORDER BY.
+/// Covers edge cases: large batches, multi-partition interleaving, repeated replaces,
+/// mixed operation sequences, projections, filters, pagination, and more.
+/// Ref: Observed behavior on Windows Cosmos DB Emulator — documents return
+///   in the order they were created when no ORDER BY is applied.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public class FakeCosmosHandlerInsertionOrderHardeningTests(EmulatorSession session) : IAsyncLifetime
+{
+    private readonly ITestContainerFixture _fixture = TestFixtureFactory.Create(session);
+    private Container _container = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _container = await _fixture.CreateContainerAsync("test-insertion-order-hardening", "/partitionKey");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    private async Task<List<T>> DrainQuery<T>(string sql, string? partitionKey = null)
+    {
+        var options = partitionKey is not null
+            ? new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) }
+            : null;
+        var iterator = _container.GetItemQueryIterator<T>(sql, requestOptions: options);
+        var results = new List<T>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    private async Task<List<T>> DrainQuery<T>(QueryDefinition queryDef, string? partitionKey = null)
+    {
+        var options = partitionKey is not null
+            ? new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) }
+            : null;
+        var iterator = _container.GetItemQueryIterator<T>(queryDef, requestOptions: options);
+        var results = new List<T>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  1. Large batch insertion order
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Inserting 50+ documents and querying without ORDER BY must return them
+    /// in exact insertion order.
+    /// </summary>
+    [Fact]
+    public async Task Query_LargeBatch_ReturnsDocsInInsertionOrder()
+    {
+        const string pk = "pk-large-batch";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 55; i++)
+        {
+            var id = $"large-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  2. Multiple partitions interleaved
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Documents inserted across 3+ partitions in an interleaved pattern must
+    /// appear in global insertion order when queried cross-partition.
+    /// </summary>
+    [Fact]
+    public async Task Query_MultiplePKsInterleaved_ReturnsCrossPartitionInsertionOrder()
+    {
+        var partitions = new[] { "pk-interleave-a", "pk-interleave-b", "pk-interleave-c" };
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 15; i++)
+        {
+            var pk = partitions[(i - 1) % 3];
+            var id = $"interleave-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>("SELECT * FROM c WHERE STARTSWITH(c.partitionKey, 'pk-interleave-')");
+
+        results.Select(r => r.Id).Should().Equal(insertedIds);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  3. Replace multiple times
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Replacing the same document 5+ times must never change its position in
+    /// the insertion order.
+    /// </summary>
+    [Fact]
+    public async Task Query_AfterMultipleReplacesOnSameDoc_PositionNeverChanges()
+    {
+        const string pk = "pk-multi-replace";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 5; i++)
+        {
+            var id = $"mr-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        // Replace the 3rd document 6 times with different content each time
+        for (var r = 1; r <= 6; r++)
+        {
+            await _container.ReplaceItemAsync(
+                new TestDocument { Id = "mr-0003", PartitionKey = pk, Name = $"Replaced-{r}", Value = 100 + r },
+                "mr-0003",
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds);
+        // Verify the content was actually updated
+        results.Single(r => r.Id == "mr-0003").Name.Should().Be("Replaced-6");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  4. Mixed operations sequence
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Complex mixed operation sequence:
+    /// create A, B, C, D, E → delete C → replace A → create F → upsert B (existing) → upsert G (new)
+    /// Expected order: A, B, D, E, F, G
+    /// </summary>
+    [Fact]
+    public async Task Query_MixedOperationSequence_ReturnsExpectedInsertionOrder()
+    {
+        const string pk = "pk-mixed-ops";
+
+        // Create A, B, C, D, E
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "mixed-A", PartitionKey = pk, Name = "A", Value = 1 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "mixed-B", PartitionKey = pk, Name = "B", Value = 2 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "mixed-C", PartitionKey = pk, Name = "C", Value = 3 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "mixed-D", PartitionKey = pk, Name = "D", Value = 4 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "mixed-E", PartitionKey = pk, Name = "E", Value = 5 },
+            new PartitionKey(pk));
+
+        // Delete C
+        await _container.DeleteItemAsync<TestDocument>("mixed-C", new PartitionKey(pk));
+
+        // Replace A (should not change position)
+        await _container.ReplaceItemAsync(
+            new TestDocument { Id = "mixed-A", PartitionKey = pk, Name = "A-replaced", Value = 100 },
+            "mixed-A",
+            new PartitionKey(pk));
+
+        // Create F (should appear at end)
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "mixed-F", PartitionKey = pk, Name = "F", Value = 6 },
+            new PartitionKey(pk));
+
+        // Upsert B (existing — should not change position)
+        await _container.UpsertItemAsync(
+            new TestDocument { Id = "mixed-B", PartitionKey = pk, Name = "B-upserted", Value = 200 },
+            new PartitionKey(pk));
+
+        // Upsert G (new — should appear at end)
+        await _container.UpsertItemAsync(
+            new TestDocument { Id = "mixed-G", PartitionKey = pk, Name = "G", Value = 7 },
+            new PartitionKey(pk));
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(
+            ["mixed-A", "mixed-B", "mixed-D", "mixed-E", "mixed-F", "mixed-G"]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  5. Query with SELECT specific fields (projection)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Projecting specific fields (SELECT c.id, c.name) must still maintain
+    /// insertion order.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithProjection_MaintainsInsertionOrder()
+    {
+        const string pk = "pk-projection";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 8; i++)
+        {
+            var id = $"proj-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Name-{i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<ProjectedDocument>(
+            $"SELECT c.id, c.name FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  6. Query with WHERE filter
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Filtering with a WHERE clause must preserve relative insertion order of
+    /// the matched documents.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithWhereFilter_MaintainsRelativeInsertionOrder()
+    {
+        const string pk = "pk-where-filter";
+
+        // Insert with alternating isActive values: true, false, true, false, true...
+        for (var i = 1; i <= 10; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument
+                {
+                    Id = $"filter-{i:D4}",
+                    PartitionKey = pk,
+                    Name = $"Doc {i}",
+                    Value = i,
+                    IsActive = i % 2 != 0
+                },
+                new PartitionKey(pk));
+        }
+
+        // Query only active documents
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}' AND c.isActive = true", pk);
+
+        // Expect odd-numbered docs only, in original order
+        results.Select(r => r.Id).Should().Equal(
+            ["filter-0001", "filter-0003", "filter-0005", "filter-0007", "filter-0009"]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  7. Query with TOP/OFFSET pagination
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Using TOP N returns the first N documents in insertion order.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithTop_ReturnsFirstNInInsertionOrder()
+    {
+        const string pk = "pk-top";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 20; i++)
+        {
+            var id = $"top-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT TOP 5 * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds.Take(5));
+    }
+
+    /// <summary>
+    /// Using OFFSET/LIMIT returns the correct page of documents in insertion order.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithOffsetLimit_ReturnsCorrectPageInInsertionOrder()
+    {
+        const string pk = "pk-offset";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 20; i++)
+        {
+            var id = $"offset-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        // Get page 2 (items 6-10)
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}' OFFSET 5 LIMIT 5", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds.Skip(5).Take(5));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  8. Empty container query
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Querying an empty container must return an empty result without errors.
+    /// </summary>
+    [Fact]
+    public async Task Query_EmptyContainer_ReturnsEmptyResults()
+    {
+        var results = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE c.partitionKey = 'pk-nonexistent'", "pk-nonexistent");
+
+        results.Should().BeEmpty();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  9. Single document
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A container with a single document must return just that document.
+    /// </summary>
+    [Fact]
+    public async Task Query_SingleDocument_ReturnsThatDocument()
+    {
+        const string pk = "pk-single-doc";
+
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "only-one", PartitionKey = pk, Name = "Solo", Value = 42 },
+            new PartitionKey(pk));
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Should().HaveCount(1);
+        results[0].Id.Should().Be("only-one");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  10. Delete all then recreate
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// After deleting all documents and inserting new ones, the new documents
+    /// should appear in their own insertion order with no ghost entries.
+    /// </summary>
+    [Fact]
+    public async Task Query_DeleteAllThenRecreate_ShowsOnlyNewDocsInOrder()
+    {
+        const string pk = "pk-del-all-recreate";
+
+        // Insert A, B, C
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "orig-A", PartitionKey = pk, Name = "A", Value = 1 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "orig-B", PartitionKey = pk, Name = "B", Value = 2 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "orig-C", PartitionKey = pk, Name = "C", Value = 3 },
+            new PartitionKey(pk));
+
+        // Delete all
+        await _container.DeleteItemAsync<TestDocument>("orig-A", new PartitionKey(pk));
+        await _container.DeleteItemAsync<TestDocument>("orig-B", new PartitionKey(pk));
+        await _container.DeleteItemAsync<TestDocument>("orig-C", new PartitionKey(pk));
+
+        // Insert D, E
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "new-D", PartitionKey = pk, Name = "D", Value = 4 },
+            new PartitionKey(pk));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "new-E", PartitionKey = pk, Name = "E", Value = 5 },
+            new PartitionKey(pk));
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(["new-D", "new-E"]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  11. Upsert-only to create multiple documents
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Using only UpsertItemAsync to create new documents must produce results
+    /// in the order the upserts were called.
+    /// </summary>
+    [Fact]
+    public async Task Query_UpsertOnlyCreates_ReturnsInUpsertCallOrder()
+    {
+        const string pk = "pk-upsert-create";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 10; i++)
+        {
+            var id = $"upsert-new-{i:D4}";
+            insertedIds.Add(id);
+            await _container.UpsertItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  12. Query with DISTINCT
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// DISTINCT on a field with duplicates must preserve the insertion order of
+    /// the first occurrence of each distinct value.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithDistinctValue_MaintainsFirstOccurrenceInsertionOrder()
+    {
+        const string pk = "pk-distinct";
+
+        // Insert documents with duplicate Value fields
+        // Values: 10, 20, 10, 30, 20, 40
+        var docs = new[]
+        {
+            ("dist-01", 10), ("dist-02", 20), ("dist-03", 10),
+            ("dist-04", 30), ("dist-05", 20), ("dist-06", 40)
+        };
+        foreach (var (id, value) in docs)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc-{value}", Value = value },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<int>(
+            $"SELECT DISTINCT VALUE c[\"value\"] FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        // First occurrences in insertion order: 10, 20, 30, 40
+        results.Should().Equal([10, 20, 30, 40]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  13. Aggregate functions don't crash
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// COUNT aggregate should return the correct count without crashing.
+    /// </summary>
+    [Fact]
+    public async Task Query_CountAggregate_ReturnsCorrectCount()
+    {
+        const string pk = "pk-agg-count";
+
+        for (var i = 1; i <= 7; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = $"agg-{i:D4}", PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<int>(
+            $"SELECT VALUE COUNT(1) FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Should().HaveCount(1);
+        results[0].Should().Be(7);
+    }
+
+    /// <summary>
+    /// SUM aggregate should return the correct sum without crashing.
+    /// </summary>
+    [Fact]
+    public async Task Query_SumAggregate_ReturnsCorrectSum()
+    {
+        const string pk = "pk-agg-sum";
+
+        for (var i = 1; i <= 5; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = $"sum-{i:D4}", PartitionKey = pk, Name = $"Doc {i}", Value = i * 10 },
+                new PartitionKey(pk));
+        }
+
+        // SUM of 10+20+30+40+50 = 150
+        var results = await DrainQuery<int>(
+            $"SELECT VALUE SUM(c[\"value\"]) FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Should().HaveCount(1);
+        results[0].Should().Be(150);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  14. Cross-partition: with vs without partition key filter
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// When querying within a single partition, insertion order within that
+    /// partition is preserved regardless of documents in other partitions.
+    /// </summary>
+    [Fact]
+    public async Task Query_SinglePartitionFilter_PreservesOrderWithinPartition()
+    {
+        var pkTarget = "pk-xpart-target";
+        var pkOther = "pk-xpart-other";
+
+        // Interleave: target-1, other-1, target-2, other-2, target-3
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "xpart-t1", PartitionKey = pkTarget, Name = "T1", Value = 1 },
+            new PartitionKey(pkTarget));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "xpart-o1", PartitionKey = pkOther, Name = "O1", Value = 2 },
+            new PartitionKey(pkOther));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "xpart-t2", PartitionKey = pkTarget, Name = "T2", Value = 3 },
+            new PartitionKey(pkTarget));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "xpart-o2", PartitionKey = pkOther, Name = "O2", Value = 4 },
+            new PartitionKey(pkOther));
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "xpart-t3", PartitionKey = pkTarget, Name = "T3", Value = 5 },
+            new PartitionKey(pkTarget));
+
+        // Query with partition key filter — should give target docs in their insertion order
+        var filteredResults = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pkTarget}'", pkTarget);
+        filteredResults.Select(r => r.Id).Should().Equal(["xpart-t1", "xpart-t2", "xpart-t3"]);
+
+        // Cross-partition query — should give all docs in global insertion order
+        var allResults = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE STARTSWITH(c.partitionKey, 'pk-xpart-')");
+        allResults.Select(r => r.Id).Should().Equal(
+            ["xpart-t1", "xpart-o1", "xpart-t2", "xpart-o2", "xpart-t3"]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  15. Rapid sequential creates
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Rapidly creating 20 documents sequentially (each awaited) must produce
+    /// results in the exact call order.
+    /// </summary>
+    [Fact]
+    public async Task Query_RapidSequentialCreates_MaintainsCallOrder()
+    {
+        const string pk = "pk-rapid";
+        var insertedIds = new List<string>();
+
+        for (var i = 1; i <= 20; i++)
+        {
+            var id = $"rapid-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Rapid {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(insertedIds);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Additional hardening: ORDER BY overrides insertion order
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A query with ORDER BY must return documents sorted by the specified field,
+    /// overriding the natural insertion order.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithOrderBy_OverridesInsertionOrder()
+    {
+        const string pk = "pk-orderby";
+
+        // Insert in non-sorted order: values 50, 10, 40, 20, 30
+        var values = new[] { 50, 10, 40, 20, 30 };
+        for (var i = 0; i < values.Length; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument
+                {
+                    Id = $"orderby-{i + 1:D4}",
+                    PartitionKey = pk,
+                    Name = $"Doc {values[i]}",
+                    Value = values[i]
+                },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}' ORDER BY c[\"value\"] ASC", pk);
+
+        results.Select(r => r.Value).Should().Equal([10, 20, 30, 40, 50]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Additional hardening: WHERE + VALUE filter preserves relative order
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A range filter (WHERE c.value > X) must preserve relative insertion order
+    /// of the matching documents.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithRangeFilter_MaintainsRelativeInsertionOrder()
+    {
+        const string pk = "pk-range-filter";
+
+        // Insert values: 5, 15, 3, 25, 8, 30, 2
+        var values = new[] { 5, 15, 3, 25, 8, 30, 2 };
+        var expectedIdsAbove10 = new List<string>();
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var id = $"range-{i + 1:D4}";
+            if (values[i] > 10) expectedIdsAbove10.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc-{values[i]}", Value = values[i] },
+                new PartitionKey(pk));
+        }
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}' AND c[\"value\"] > 10", pk);
+
+        // Expected: range-0002 (15), range-0004 (25), range-0006 (30) — in insertion order
+        results.Select(r => r.Id).Should().Equal(expectedIdsAbove10);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Additional hardening: Delete from middle, verify remaining order
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Deleting multiple non-consecutive documents must not disturb the relative
+    /// order of the remaining documents.
+    /// </summary>
+    [Fact]
+    public async Task Query_AfterMultipleNonConsecutiveDeletes_PreservesRemainingOrder()
+    {
+        const string pk = "pk-multi-del";
+
+        for (var i = 1; i <= 10; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = $"mdel-{i:D4}", PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        // Delete positions 2, 5, 8 (non-consecutive)
+        await _container.DeleteItemAsync<TestDocument>("mdel-0002", new PartitionKey(pk));
+        await _container.DeleteItemAsync<TestDocument>("mdel-0005", new PartitionKey(pk));
+        await _container.DeleteItemAsync<TestDocument>("mdel-0008", new PartitionKey(pk));
+
+        var results = await DrainQuery<TestDocument>(
+            $"SELECT * FROM c WHERE c.partitionKey = '{pk}'", pk);
+
+        results.Select(r => r.Id).Should().Equal(
+            ["mdel-0001", "mdel-0003", "mdel-0004", "mdel-0006", "mdel-0007", "mdel-0009", "mdel-0010"]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Projection helper models
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    private class ProjectedDocument
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = default!;
+
+        [JsonProperty("name")]
+        public string Name { get; set; } = default!;
+    }
+
+}

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/FakeCosmosHandlerInsertionOrderTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/FakeCosmosHandlerInsertionOrderTests.cs
@@ -1,0 +1,245 @@
+using AwesomeAssertions;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Tests that queries without an ORDER BY clause return documents in insertion order,
+/// matching the observed behavior of real Cosmos DB and the Windows Cosmos Emulator.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public class FakeCosmosHandlerInsertionOrderTests(EmulatorSession session) : IAsyncLifetime
+{
+    private readonly ITestContainerFixture _fixture = TestFixtureFactory.Create(session);
+    private Container _container = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _container = await _fixture.CreateContainerAsync("test-insertion-order", "/partitionKey");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    private async Task<List<T>> DrainQuery<T>(string sql, string? partitionKey = null)
+    {
+        var options = partitionKey is not null
+            ? new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) }
+            : null;
+        var iterator = _container.GetItemQueryIterator<T>(sql, requestOptions: options);
+        var results = new List<T>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    private async Task<List<T>> DrainQuery<T>(QueryDefinition queryDef, string? partitionKey = null)
+    {
+        var options = partitionKey is not null
+            ? new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) }
+            : null;
+        var iterator = _container.GetItemQueryIterator<T>(queryDef, requestOptions: options);
+        var results = new List<T>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Insertion order — queries without ORDER BY
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Verifies that documents queried within a single partition are returned in
+    /// insertion order when no ORDER BY clause is specified.
+    /// Ref: Observed behavior on Windows Cosmos DB Emulator — documents return
+    ///   in the order they were created when no ORDER BY is applied.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithoutOrderBy_ReturnsSinglePartitionDocsInInsertionOrder()
+    {
+        // Arrange — insert 10 documents sequentially
+        var insertedIds = new List<string>();
+        for (var i = 1; i <= 10; i++)
+        {
+            var id = $"order-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = "pk-order", Name = $"Doc {i}", Value = i },
+                new PartitionKey("pk-order"));
+        }
+
+        // Act — query without ORDER BY
+        var results = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE c.partitionKey = 'pk-order'",
+            "pk-order");
+
+        // Assert — returned IDs match insertion order
+        var returnedIds = results.Select(r => r.Id).ToList();
+        returnedIds.Should().Equal(insertedIds);
+    }
+
+    /// <summary>
+    /// Verifies that a cross-partition query without ORDER BY returns documents
+    /// in insertion order across all partitions.
+    /// </summary>
+    [Fact]
+    public async Task Query_WithoutOrderBy_ReturnsCrossPartitionDocsInInsertionOrder()
+    {
+        // Arrange — insert documents across two partitions, interleaved
+        var insertedIds = new List<string>();
+        for (var i = 1; i <= 8; i++)
+        {
+            var pk = i % 2 == 0 ? "pk-even" : "pk-odd";
+            var id = $"cross-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = pk, Name = $"Doc {i}", Value = i },
+                new PartitionKey(pk));
+        }
+
+        // Act — cross-partition query without ORDER BY
+        var results = await DrainQuery<TestDocument>("SELECT * FROM c");
+
+        // Assert — returned IDs match insertion order
+        var returnedIds = results.Select(r => r.Id).ToList();
+        returnedIds.Should().Equal(insertedIds);
+    }
+
+    /// <summary>
+    /// Verifies that replacing a document does not change its position in the
+    /// insertion order (replace preserves original creation position).
+    /// </summary>
+    [Fact]
+    public async Task Query_AfterReplace_PreservesInsertionOrder()
+    {
+        // Arrange — insert 5 documents
+        var insertedIds = new List<string>();
+        for (var i = 1; i <= 5; i++)
+        {
+            var id = $"replace-{i:D4}";
+            insertedIds.Add(id);
+            await _container.CreateItemAsync(
+                new TestDocument { Id = id, PartitionKey = "pk-replace", Name = $"Doc {i}", Value = i },
+                new PartitionKey("pk-replace"));
+        }
+
+        // Replace the 2nd document
+        await _container.ReplaceItemAsync(
+            new TestDocument { Id = "replace-0002", PartitionKey = "pk-replace", Name = "Updated", Value = 99 },
+            "replace-0002",
+            new PartitionKey("pk-replace"));
+
+        // Act
+        var results = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE c.partitionKey = 'pk-replace'",
+            "pk-replace");
+
+        // Assert — order unchanged
+        var returnedIds = results.Select(r => r.Id).ToList();
+        returnedIds.Should().Equal(insertedIds);
+    }
+
+    /// <summary>
+    /// Verifies that deleting a document and re-creating it places the new
+    /// document at the end (new insertion position).
+    /// </summary>
+    [Fact]
+    public async Task Query_AfterDeleteAndRecreate_NewDocAppearsAtEnd()
+    {
+        // Arrange — insert 5 documents
+        for (var i = 1; i <= 5; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = $"delrec-{i:D4}", PartitionKey = "pk-delrec", Name = $"Doc {i}", Value = i },
+                new PartitionKey("pk-delrec"));
+        }
+
+        // Delete the 2nd document
+        await _container.DeleteItemAsync<TestDocument>("delrec-0002", new PartitionKey("pk-delrec"));
+
+        // Re-create with same ID
+        await _container.CreateItemAsync(
+            new TestDocument { Id = "delrec-0002", PartitionKey = "pk-delrec", Name = "Recreated", Value = 200 },
+            new PartitionKey("pk-delrec"));
+
+        // Act
+        var results = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE c.partitionKey = 'pk-delrec'",
+            "pk-delrec");
+
+        // Assert — recreated doc is now at the end
+        var returnedIds = results.Select(r => r.Id).ToList();
+        returnedIds.Should().Equal(["delrec-0001", "delrec-0003", "delrec-0004", "delrec-0005", "delrec-0002"]);
+    }
+
+    /// <summary>
+    /// Verifies that upsert of a new document places it at the end of
+    /// the insertion order (same as create).
+    /// </summary>
+    [Fact]
+    public async Task Query_UpsertNewDoc_AppearsAtEnd()
+    {
+        // Arrange — insert 3 documents
+        for (var i = 1; i <= 3; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = $"upsert-{i:D4}", PartitionKey = "pk-upsert", Name = $"Doc {i}", Value = i },
+                new PartitionKey("pk-upsert"));
+        }
+
+        // Upsert a new document
+        await _container.UpsertItemAsync(
+            new TestDocument { Id = "upsert-0004", PartitionKey = "pk-upsert", Name = "New", Value = 4 },
+            new PartitionKey("pk-upsert"));
+
+        // Act
+        var results = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE c.partitionKey = 'pk-upsert'",
+            "pk-upsert");
+
+        // Assert — upserted new doc at end
+        var returnedIds = results.Select(r => r.Id).ToList();
+        returnedIds.Should().Equal(["upsert-0001", "upsert-0002", "upsert-0003", "upsert-0004"]);
+    }
+
+    /// <summary>
+    /// Verifies that upsert of an existing document preserves its original
+    /// insertion position (same as replace).
+    /// </summary>
+    [Fact]
+    public async Task Query_UpsertExistingDoc_PreservesInsertionOrder()
+    {
+        // Arrange — insert 3 documents
+        for (var i = 1; i <= 3; i++)
+        {
+            await _container.CreateItemAsync(
+                new TestDocument { Id = $"upsert-ex-{i:D4}", PartitionKey = "pk-upsert-ex", Name = $"Doc {i}", Value = i },
+                new PartitionKey("pk-upsert-ex"));
+        }
+
+        // Upsert an existing document (update)
+        await _container.UpsertItemAsync(
+            new TestDocument { Id = "upsert-ex-0002", PartitionKey = "pk-upsert-ex", Name = "Updated", Value = 99 },
+            new PartitionKey("pk-upsert-ex"));
+
+        // Act
+        var results = await DrainQuery<TestDocument>(
+            "SELECT * FROM c WHERE c.partitionKey = 'pk-upsert-ex'",
+            "pk-upsert-ex");
+
+        // Assert — order preserved
+        var returnedIds = results.Select(r => r.Id).ToList();
+        returnedIds.Should().Equal(["upsert-ex-0001", "upsert-ex-0002", "upsert-ex-0003"]);
+    }
+}

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue18EdgeCaseIntegrationTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue18EdgeCaseIntegrationTests.cs
@@ -11,15 +11,11 @@ namespace CosmosDB.InMemoryEmulator.Tests;
 /// verifying that exceptions are exactly <see cref="CosmosException"/> and carry the
 /// expected status codes.
 ///
-/// Tagged <c>EmulatorFlaky</c>: the entire class has been reproducibly failing on
-/// emulator-linux / emulator-windows targets in CI — the emulators return 503
-/// ("high demand in this region") under the concurrent error-path load this class
-/// exercises, where the in-memory backend returns the expected 4xx/5xx. The
-/// behaviour under test is still validated on the in-memory target; emulator
-/// parity would be nice-to-have but isn't load-bearing.
+/// The concurrent test uses adaptive concurrency: lower volume when targeting a real
+/// emulator to avoid overwhelming its partition service with 503 "high demand" errors,
+/// while still validating the same thread-safety behaviour.
 /// </summary>
 [Collection(IntegrationCollection.Name)]
-[Trait(TestTraits.Target, TestTraits.EmulatorFlaky)]
 public class Issue18EdgeCaseIntegrationTests(EmulatorSession session) : IAsyncLifetime
 {
     private readonly ITestContainerFixture _fixture = TestFixtureFactory.Create(session);
@@ -188,7 +184,10 @@ public class Issue18EdgeCaseIntegrationTests(EmulatorSession session) : IAsyncLi
     [Fact]
     public async Task ConcurrentReadsOfNonExistent_AllThrowCosmosException()
     {
-        const int concurrency = 50;
+        // Use lower concurrency on emulators to avoid overwhelming the partition
+        // service (503 "high demand in this region"). The behavioural assertion is
+        // the same — all reads of non-existent items throw CosmosException(404).
+        var concurrency = session.IsEmulator ? 10 : 50;
         var tasks = Enumerable.Range(0, concurrency).Select(async i =>
         {
             var ex = await Assert.ThrowsAsync<CosmosException>(async () =>

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue64CountTernaryUndefinedTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue64CountTernaryUndefinedTests.cs
@@ -1,0 +1,219 @@
+using AwesomeAssertions;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Regression tests for GitHub Issue #64 — COUNT(expr > 0 ? 1 : undefined)
+/// incorrectly counts documents where the expression evaluates to undefined.
+///
+/// Root cause: <c>ExprToString</c> in <c>CosmosSqlParser</c> did not parenthesise
+/// ternary/coalesce sub-expressions within higher-precedence binary operators, so the
+/// round-tripped SQL was re-parsed into a different AST.
+///
+/// Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/ternary-coalesce-operators
+///   Ternary (?) and Coalesce (??) have the lowest operator precedence in Cosmos DB SQL.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public class Issue64CountTernaryUndefinedTests(EmulatorSession session) : IAsyncLifetime
+{
+	private readonly ITestContainerFixture _fixture = TestFixtureFactory.Create(session);
+	private Container _container = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		_container = await _fixture.CreateContainerAsync("issue64", "/partitionKey");
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		await _fixture.DisposeAsync();
+	}
+
+	private async Task<List<T>> DrainQuery<T>(string sql)
+	{
+		var iterator = _container.GetItemQueryIterator<T>(sql);
+		var results = new List<T>();
+		while (iterator.HasMoreResults)
+		{
+			var page = await iterator.ReadNextAsync();
+			results.AddRange(page);
+		}
+		return results;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	//  SELECT VALUE with ternary returning undefined
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	[Fact]
+	public async Task SelectValue_SimpleTernary_WhenConditionFalse_ReturnsEmpty()
+	{
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", amount = 0 }, new PartitionKey("pk1"));
+
+		// amount = 0, so (0 > 0) is false → ternary returns undefined → excluded from results
+		var results = await DrainQuery<JToken>(
+			"SELECT VALUE c.amount > 0 ? 1 : undefined FROM c");
+
+		results.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task SelectValue_SimpleTernary_WhenConditionTrue_ReturnsValue()
+	{
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", amount = 5 }, new PartitionKey("pk1"));
+
+		// amount = 5, so (5 > 0) is true → ternary returns 1
+		var results = await DrainQuery<long>(
+			"SELECT VALUE c.amount > 0 ? 1 : undefined FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task SelectValue_NestedTernary_WhenInnerResolvesAndComparisonFails_ReturnsEmpty()
+	{
+		// creditValue.amount = 0, so inner ternary resolves to 0; 0 > 0 is false → undefined
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", creditValue = new { amount = 0 }, grossValue = new { amount = 100 } },
+			new PartitionKey("pk1"));
+
+		var results = await DrainQuery<JToken>(
+			"SELECT VALUE (IS_DEFINED(c.creditValue) ? c.creditValue.amount : c.grossValue.amount) > 0 ? 1 : undefined FROM c");
+
+		results.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task SelectValue_NestedTernary_WhenInnerResolvesAndComparisonSucceeds_ReturnsValue()
+	{
+		// creditValue.amount = 50, so inner ternary resolves to 50; 50 > 0 is true → 1
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", creditValue = new { amount = 50 }, grossValue = new { amount = 100 } },
+			new PartitionKey("pk1"));
+
+		var results = await DrainQuery<long>(
+			"SELECT VALUE (IS_DEFINED(c.creditValue) ? c.creditValue.amount : c.grossValue.amount) > 0 ? 1 : undefined FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(1);
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	//  COUNT with ternary returning undefined — the core bug scenario
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	[Fact]
+	public async Task Count_SimpleTernary_WhenConditionFalse_ShouldNotCount()
+	{
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", amount = 0 }, new PartitionKey("pk1"));
+
+		// amount = 0, so (0 > 0) is false → undefined → COUNT should skip
+		var results = await DrainQuery<int>(
+			"SELECT VALUE COUNT(c.amount > 0 ? 1 : undefined) FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task Count_SimpleTernary_MixedDocuments_CountsOnlyMatching()
+	{
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", amount = 0 }, new PartitionKey("pk1"));
+		await _container.CreateItemAsync(
+			new { id = "2", partitionKey = "pk1", amount = 5 }, new PartitionKey("pk1"));
+		await _container.CreateItemAsync(
+			new { id = "3", partitionKey = "pk1", amount = -1 }, new PartitionKey("pk1"));
+
+		// Only id=2 (amount=5) satisfies amount > 0
+		var results = await DrainQuery<int>(
+			"SELECT VALUE COUNT(c.amount > 0 ? 1 : undefined) FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task Count_NestedTernary_WhenInnerResolvesToZero_ShouldNotCount()
+	{
+		// This is the exact bug scenario from the issue:
+		// creditValue.amount = 0, IS_DEFINED(c.creditValue) is true, so inner ternary → 0
+		// 0 > 0 is false → outer ternary returns undefined → COUNT should NOT count this doc
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", creditValue = new { amount = 0 }, grossValue = new { amount = 100 } },
+			new PartitionKey("pk1"));
+
+		var results = await DrainQuery<int>(
+			"SELECT VALUE COUNT((IS_DEFINED(c.creditValue) ? c.creditValue.amount : c.grossValue.amount) > 0 ? 1 : undefined) FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task Count_NestedTernary_WhenInnerResolvesToPositive_ShouldCount()
+	{
+		// creditValue.amount = 50, IS_DEFINED(c.creditValue) is true, so inner ternary → 50
+		// 50 > 0 is true → outer ternary returns 1 → COUNT SHOULD count this doc
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", creditValue = new { amount = 50 }, grossValue = new { amount = 100 } },
+			new PartitionKey("pk1"));
+
+		var results = await DrainQuery<int>(
+			"SELECT VALUE COUNT((IS_DEFINED(c.creditValue) ? c.creditValue.amount : c.grossValue.amount) > 0 ? 1 : undefined) FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task Count_NestedTernary_FallsBackToGrossValue_WhenCreditUndefined()
+	{
+		// creditValue is NOT defined, so IS_DEFINED is false → inner ternary → grossValue.amount = 200
+		// 200 > 0 is true → outer ternary returns 1 → COUNT SHOULD count
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", grossValue = new { amount = 200 } },
+			new PartitionKey("pk1"));
+
+		var results = await DrainQuery<int>(
+			"SELECT VALUE COUNT((IS_DEFINED(c.creditValue) ? c.creditValue.amount : c.grossValue.amount) > 0 ? 1 : undefined) FROM c");
+
+		results.Should().ContainSingle().Which.Should().Be(1);
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	//  Multi-aggregate query (mirrors the original issue's query pattern)
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	[Fact]
+	public async Task Count_MultipleAggregatesWithTernary_IssueScenario()
+	{
+		// Mirrors the exact pattern from the bug report
+		await _container.CreateItemAsync(new
+		{
+			id = "doc1",
+			partitionKey = "pk1",
+			merchantId = "m1",
+			transactionType = "Settlement",
+			settlementDate = "2023-09-07",
+			creditValue = new { amount = 0 },
+			grossSettlementValue = new { amount = 1000.25 },
+			upfrontPaymentValue = new { amount = 1000.25 }
+		}, new PartitionKey("pk1"));
+
+		var query =
+			"SELECT " +
+			"COUNT((IS_DEFINED(c.creditValue) ? c.creditValue.amount : c.grossSettlementValue.amount) > 0 ? 1 : undefined) AS NumberTransactions, " +
+			"COUNT(c.upfrontPaymentValue.amount > 0 ? 1 : undefined) AS UpfrontPaymentCount " +
+			"FROM c WHERE c.transactionType = 'Settlement' AND c.settlementDate = '2023-09-07' AND c.merchantId = 'm1'";
+
+		var results = await DrainQuery<JObject>(query);
+
+		var row = results.Should().ContainSingle().Which;
+		// creditValue.amount = 0 → inner ternary resolves to 0 → 0 > 0 is false → undefined → NOT counted
+		row["NumberTransactions"]!.Value<int>().Should().Be(0);
+		// upfrontPaymentValue.amount = 1000.25 → 1000.25 > 0 is true → 1 → counted
+		row["UpfrontPaymentCount"]!.Value<int>().Should().Be(1);
+	}
+}

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue67StringLiteralAliasTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue67StringLiteralAliasTests.cs
@@ -1,0 +1,144 @@
+using AwesomeAssertions;
+using CosmosDB.InMemoryEmulator.Tests.Infrastructure;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Regression tests for GitHub Issue #67 — String literal aliases in aggregate queries
+/// return null on Linux (where ServiceInterop is unavailable).
+///
+/// Root cause: <c>ProjectAggregateFields</c> did not evaluate non-aggregate literal
+/// expressions (like <c>'Settlement' AS Label</c>). Instead it fell through to a
+/// path-lookup branch that called <c>SelectToken("'Settlement'")</c> → null.
+///
+/// Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/select
+///   "The SELECT clause supports arbitrary expressions including literal values."
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public class Issue67StringLiteralAliasTests(EmulatorSession session) : IAsyncLifetime
+{
+	private readonly ITestContainerFixture _fixture = TestFixtureFactory.Create(session);
+	private Container _container = null!;
+
+	public async ValueTask InitializeAsync()
+	{
+		_container = await _fixture.CreateContainerAsync("issue67", "/partitionKey");
+
+		await _container.CreateItemAsync(
+			new { id = "1", partitionKey = "pk1", type = "Settlement", amount = 100.0m },
+			new PartitionKey("pk1"));
+		await _container.CreateItemAsync(
+			new { id = "2", partitionKey = "pk1", type = "Settlement", amount = 200.0m },
+			new PartitionKey("pk1"));
+		await _container.CreateItemAsync(
+			new { id = "3", partitionKey = "pk1", type = "Refund", amount = 50.0m },
+			new PartitionKey("pk1"));
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		await _fixture.DisposeAsync();
+	}
+
+	private async Task<List<T>> DrainQuery<T>(string sql, PartitionKey? pk = null)
+	{
+		var opts = pk is not null ? new QueryRequestOptions { PartitionKey = pk } : null;
+		var iterator = _container.GetItemQueryIterator<T>(sql, requestOptions: opts);
+		var results = new List<T>();
+		while (iterator.HasMoreResults)
+		{
+			var page = await iterator.ReadNextAsync();
+			results.AddRange(page);
+		}
+		return results;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	//  String literal in aggregate SELECT projection
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	[Fact]
+	public async Task StringLiteralAlias_InAggregateQuery_ShouldDeserializeCorrectly()
+	{
+		// Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/select
+		//   "The SELECT clause supports arbitrary expressions including literal values."
+		var results = await DrainQuery<JObject>(
+			"SELECT 'Settlement' AS Label, COUNT(1) AS ItemCount, SUM(c.amount) AS Total FROM c WHERE c.type = 'Settlement'",
+			new PartitionKey("pk1"));
+
+		results.Should().ContainSingle();
+		var result = results[0];
+		result["Label"]!.Value<string>().Should().Be("Settlement");
+		result["ItemCount"]!.Value<int>().Should().Be(2);
+		result["Total"]!.Value<decimal>().Should().Be(300.0m);
+	}
+
+	[Fact]
+	public async Task StringLiteralAlias_WithMultipleQueries_ShouldReturnDistinctLiterals()
+	{
+		var settlements = await DrainQuery<JObject>(
+			"SELECT 'Settlement' AS Label, COUNT(1) AS ItemCount, SUM(c.amount) AS Total FROM c WHERE c.type = 'Settlement'",
+			new PartitionKey("pk1"));
+
+		var refunds = await DrainQuery<JObject>(
+			"SELECT 'Refund' AS Label, COUNT(1) AS ItemCount, SUM(c.amount) AS Total FROM c WHERE c.type = 'Refund'",
+			new PartitionKey("pk1"));
+
+		settlements.Should().ContainSingle();
+		settlements[0]["Label"]!.Value<string>().Should().Be("Settlement");
+		settlements[0]["ItemCount"]!.Value<int>().Should().Be(2);
+		settlements[0]["Total"]!.Value<decimal>().Should().Be(300.0m);
+
+		refunds.Should().ContainSingle();
+		refunds[0]["Label"]!.Value<string>().Should().Be("Refund");
+		refunds[0]["ItemCount"]!.Value<int>().Should().Be(1);
+		refunds[0]["Total"]!.Value<decimal>().Should().Be(50.0m);
+	}
+
+	[Fact]
+	public async Task NumericLiteralAlias_InAggregateQuery_ShouldDeserializeCorrectly()
+	{
+		// Also test numeric and boolean literal aliases for completeness
+		var results = await DrainQuery<JObject>(
+			"SELECT 42 AS MagicNumber, COUNT(1) AS ItemCount FROM c WHERE c.type = 'Settlement'",
+			new PartitionKey("pk1"));
+
+		results.Should().ContainSingle();
+		results[0]["MagicNumber"]!.Value<int>().Should().Be(42);
+		results[0]["ItemCount"]!.Value<int>().Should().Be(2);
+	}
+
+	[Fact]
+	public async Task BooleanLiteralAlias_InAggregateQuery_ShouldDeserializeCorrectly()
+	{
+		var results = await DrainQuery<JObject>(
+			"SELECT true AS IsActive, COUNT(1) AS ItemCount FROM c WHERE c.type = 'Settlement'",
+			new PartitionKey("pk1"));
+
+		results.Should().ContainSingle();
+		results[0]["IsActive"]!.Value<bool>().Should().BeTrue();
+		results[0]["ItemCount"]!.Value<int>().Should().Be(2);
+	}
+
+	[Fact]
+	public async Task NullLiteralAlias_InAggregateQuery_ShouldDeserializeCorrectly()
+	{
+		var results = await DrainQuery<JObject>(
+			"SELECT null AS Nothing, COUNT(1) AS ItemCount FROM c WHERE c.type = 'Settlement'",
+			new PartitionKey("pk1"));
+
+		results.Should().ContainSingle();
+		results[0]["ItemCount"]!.Value<int>().Should().Be(2);
+
+		// On Linux (no ServiceInterop), our ProjectAggregateFields correctly returns null.
+		// On Windows, ServiceInterop's pipeline may omit null literal fields from aggregates.
+		var nothingToken = results[0]["Nothing"];
+		if (nothingToken is not null)
+		{
+			nothingToken.Type.Should().Be(JTokenType.Null);
+		}
+	}
+}

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue70FilterPredicateMissingPropertyTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Integration/Issue70FilterPredicateMissingPropertyTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using AwesomeAssertions;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace CosmosDB.InMemoryEmulator.Tests;
+
+/// <summary>
+/// Regression tests for GitHub Issue #70 — FilterPredicate does not treat missing
+/// properties as null when NullValueHandling.Ignore is used.
+///
+/// When a document is serialized with NullValueHandling.Ignore, null properties are
+/// omitted entirely. Real Cosmos DB treats these missing properties as null during
+/// FilterPredicate evaluation, so "FROM c WHERE c.prop = null" should match.
+///
+/// Tagged InMemoryOnly because the Windows Cosmos DB Emulator (v2.14.0) does not
+/// support FilterPredicate syntax — it returns 400 BadRequest (tracked: #53).
+///
+/// Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update#filter-predicate
+///   "The filter predicate is evaluated against the existing state of the document."
+///   Missing properties are semantically equivalent to null in filter predicate evaluation.
+/// </summary>
+public class Issue70FilterPredicateMissingPropertyTests : IAsyncLifetime
+{
+    private InMemoryCosmosResult _cosmos = null!;
+    private Container _container = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        _cosmos = InMemoryCosmos.Create("issue70", "/partitionKey",
+            configureOptions: opts => opts.Serializer = new CosmosJsonDotNetSerializer(new JsonSerializerSettings
+            {
+                ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new CamelCaseNamingStrategy()
+                },
+                NullValueHandling = NullValueHandling.Ignore
+            }));
+        _container = _cosmos.Container;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _cosmos.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    [Trait(TestTraits.Target, TestTraits.InMemoryOnly)]
+    [Fact]
+    public async Task PatchWithFilterPredicate_MissingPropertyEqualsNull_Succeeds()
+    {
+        // linkedId is null → will NOT be serialized due to NullValueHandling.Ignore
+        var document = new
+        {
+            id = Guid.NewGuid().ToString(),
+            partitionKey = "pk-1",
+            linkedId = (string?)null,
+            name = "test"
+        };
+        await _container.CreateItemAsync(document, new PartitionKey("pk-1"));
+
+        // This FilterPredicate should match because the missing property should be treated as null
+        var patchOperations = new[] { PatchOperation.Set("/linkedId", Guid.NewGuid().ToString()) };
+        var options = new PatchItemRequestOptions
+        {
+            FilterPredicate = "FROM c WHERE c.linkedId = null"
+        };
+
+        var response = await _container.PatchItemAsync<dynamic>(
+            document.id, new PartitionKey("pk-1"), patchOperations, options);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Trait(TestTraits.Target, TestTraits.InMemoryOnly)]
+    [Fact]
+    public async Task PatchWithFilterPredicate_MissingPropertyNotEqualNull_FailsPrecondition()
+    {
+        // linkedId is null → will NOT be serialized due to NullValueHandling.Ignore
+        var document = new
+        {
+            id = Guid.NewGuid().ToString(),
+            partitionKey = "pk-1",
+            linkedId = (string?)null,
+            name = "test"
+        };
+        await _container.CreateItemAsync(document, new PartitionKey("pk-1"));
+
+        // WHERE c.linkedId != null should NOT match when property is missing (treated as null)
+        var patchOperations = new[] { PatchOperation.Set("/name", "updated") };
+        var options = new PatchItemRequestOptions
+        {
+            FilterPredicate = "FROM c WHERE c.linkedId != null"
+        };
+
+        var act = () => _container.PatchItemAsync<dynamic>(
+            document.id, new PartitionKey("pk-1"), patchOperations, options);
+
+        var ex = await act.Should().ThrowAsync<CosmosException>();
+        ex.Which.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Trait(TestTraits.Target, TestTraits.InMemoryOnly)]
+    [Fact]
+    public async Task PatchWithFilterPredicate_ExplicitNullPropertyEqualsNull_Succeeds()
+    {
+        // Use stream to explicitly write null (bypassing NullValueHandling.Ignore)
+        var id = Guid.NewGuid().ToString();
+        var json = $$"""{"id":"{{id}}","partitionKey":"pk-1","linkedId":null,"name":"test"}""";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        await _container.CreateItemStreamAsync(stream, new PartitionKey("pk-1"));
+
+        var patchOperations = new[] { PatchOperation.Set("/linkedId", "new-value") };
+        var options = new PatchItemRequestOptions
+        {
+            FilterPredicate = "FROM c WHERE c.linkedId = null"
+        };
+
+        var response = await _container.PatchItemAsync<dynamic>(
+            id, new PartitionKey("pk-1"), patchOperations, options);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Trait(TestTraits.Target, TestTraits.InMemoryOnly)]
+    [Fact]
+    public async Task PatchWithFilterPredicate_MissingPropertyEqualsValue_FailsPrecondition()
+    {
+        // linkedId is null → will NOT be serialized due to NullValueHandling.Ignore
+        var document = new
+        {
+            id = Guid.NewGuid().ToString(),
+            partitionKey = "pk-1",
+            linkedId = (string?)null,
+            name = "test"
+        };
+        await _container.CreateItemAsync(document, new PartitionKey("pk-1"));
+
+        // WHERE c.linkedId = 'some-value' should NOT match — missing property treated as null ≠ 'some-value'
+        var patchOperations = new[] { PatchOperation.Set("/name", "updated") };
+        var options = new PatchItemRequestOptions
+        {
+            FilterPredicate = "FROM c WHERE c.linkedId = 'some-value'"
+        };
+
+        var act = () => _container.PatchItemAsync<dynamic>(
+            document.id, new PartitionKey("pk-1"), patchOperations, options);
+
+        var ex = await act.Should().ThrowAsync<CosmosException>();
+        ex.Which.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+    }
+}
+
+/// <summary>
+/// A simple Newtonsoft.Json-based CosmosSerializer for test use.
+/// The SDK's built-in one is internal, so we provide a minimal implementation.
+/// </summary>
+internal sealed class CosmosJsonDotNetSerializer : CosmosSerializer
+{
+    private readonly JsonSerializer _serializer;
+
+    public CosmosJsonDotNetSerializer(JsonSerializerSettings settings)
+    {
+        _serializer = JsonSerializer.Create(settings);
+    }
+
+    public override T FromStream<T>(Stream stream)
+    {
+        using var sr = new StreamReader(stream);
+        using var jr = new JsonTextReader(sr);
+        return _serializer.Deserialize<T>(jr)!;
+    }
+
+    public override Stream ToStream<T>(T input)
+    {
+        var ms = new MemoryStream();
+        using (var sw = new StreamWriter(ms, leaveOpen: true))
+        using (var jw = new JsonTextWriter(sw))
+        {
+            _serializer.Serialize(jw, input);
+            jw.Flush();
+        }
+        ms.Position = 0;
+        return ms;
+    }
+}

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Shared/Infrastructure/EmulatorSession.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Shared/Infrastructure/EmulatorSession.cs
@@ -282,6 +282,10 @@ internal static class EmulatorRetry
         // can become reachable before its account is fully initialised. Retry until ready.
         CosmosException ce when ce.StatusCode == System.Net.HttpStatusCode.Forbidden
                               && ce.SubStatusCode == 1008 => true,
+        // 404/0 = Windows emulator intermediate startup state: HTTP server is reachable
+        // but internal metadata services haven't fully materialised yet.
+        CosmosException ce when ce.StatusCode == System.Net.HttpStatusCode.NotFound
+                              && ce.SubStatusCode == 0 => true,
         CosmosException ce => ce.StatusCode is
             System.Net.HttpStatusCode.ServiceUnavailable or
             System.Net.HttpStatusCode.InternalServerError or

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Shared/Infrastructure/TestTraits.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Shared/Infrastructure/TestTraits.cs
@@ -17,13 +17,4 @@ public static class TestTraits
 
     /// <summary>Documents a known divergence between in-memory and emulator.</summary>
     public const string KnownDivergence = "KnownDivergence";
-
-    /// <summary>
-    /// Test is reproducibly flaky against the Linux Docker / Windows Cosmos DB
-    /// emulators due to emulator-side instability (typically 503 responses where
-    /// the in-memory backend returns the expected status). Excluded from
-    /// emulator-target runs in scripts/run-tests.ps1 to keep CI signal clean.
-    /// In-memory runs are unaffected — these tests still validate behaviour there.
-    /// </summary>
-    public const string EmulatorFlaky = "EmulatorFlaky";
 }

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/FakeCosmosHandlerAdvancedFeatureTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/FakeCosmosHandlerAdvancedFeatureTests.cs
@@ -75,7 +75,7 @@ public class FakeCosmosHandlerAdvancedFeatureTests : IDisposable
     [Fact]
     public async Task UDF_RegisteredOnBackingContainer_UsableInQueryThroughHandler()
     {
-        _inMemoryContainer.RegisterUdf("doubleIt", args => (double)args[0] * 2);
+        _inMemoryContainer.RegisterUdf("doubleIt", args => Convert.ToDouble(args[0]) * 2);
 
         await _container.CreateItemAsync(
             new TestDocument { Id = "1", PartitionKey = "pk1", Name = "Alice", Value = 5,

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/InMemoryCosmosTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/InMemoryCosmosTests.cs
@@ -125,7 +125,7 @@ public class InMemoryCosmosCreateWithOptionsTests
     }
 
     [Fact]
-    public async Task Create_WithConfigureContainer_ConfiguresContainer()
+    public void Create_WithConfigureContainer_ConfiguresContainer()
     {
         using var cosmos = InMemoryCosmos.Create("orders", "/partitionKey",
             configureContainer: c => c.DefaultTimeToLive = 3600);
@@ -250,7 +250,7 @@ public class InMemoryCosmosBuilderTests
     }
 
     [Fact]
-    public async Task Builder_WrapHandler_WrapsAllHandlers()
+    public void Builder_WrapHandler_WrapsAllHandlers()
     {
         var callCount = 0;
         using var cosmos = InMemoryCosmos.Builder()
@@ -278,7 +278,7 @@ public class InMemoryCosmosBuilderTests
     }
 
     [Fact]
-    public async Task Builder_AddContainerWithConfigure_ConfiguresContainer()
+    public void Builder_AddContainerWithConfigure_ConfiguresContainer()
     {
         using var cosmos = InMemoryCosmos.Builder()
             .AddContainer("orders", "/partitionKey", container =>

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/PatchDeepDiveTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/PatchDeepDiveTests.cs
@@ -594,6 +594,116 @@ public class PatchFilterPredicateEdgeTests
 }
 
 
+// ── Category K2: FilterPredicate Missing Property = null (Issue #70) ─────────
+
+/// <summary>
+/// Regression tests for Issue #70: FilterPredicate should treat missing properties as null.
+/// Uses InMemoryContainer directly with raw JSON streams to control property presence.
+///
+/// Ref: https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update#filter-predicate
+///   "The filter predicate is evaluated against the existing state of the document."
+///   Missing properties are semantically equivalent to null in filter predicate evaluation.
+/// </summary>
+public class PatchFilterPredicateMissingPropertyTests
+{
+    [Fact]
+    public async Task Patch_FilterPredicate_MissingPropertyEqualsNull_Succeeds()
+    {
+        var container = new InMemoryContainer("test", "/partitionKey");
+        // Document without linkedId property at all
+        await container.CreateItemStreamAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes(
+                """{"id":"1","partitionKey":"pk1","name":"test"}""")),
+            new PartitionKey("pk1"));
+
+        var result = await container.PatchItemAsync<JObject>(
+            "1", new PartitionKey("pk1"),
+            [PatchOperation.Set("/linkedId", "new-value")],
+            new PatchItemRequestOptions { FilterPredicate = "FROM c WHERE c.linkedId = null" });
+
+        result.Resource["linkedId"]!.Value<string>().Should().Be("new-value");
+    }
+
+    [Fact]
+    public async Task Patch_FilterPredicate_MissingPropertyNotEqualNull_ThrowsPreconditionFailed()
+    {
+        var container = new InMemoryContainer("test", "/partitionKey");
+        // Document without linkedId property at all
+        await container.CreateItemStreamAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes(
+                """{"id":"1","partitionKey":"pk1","name":"test"}""")),
+            new PartitionKey("pk1"));
+
+        var act = () => container.PatchItemAsync<JObject>(
+            "1", new PartitionKey("pk1"),
+            [PatchOperation.Set("/name", "updated")],
+            new PatchItemRequestOptions { FilterPredicate = "FROM c WHERE c.linkedId != null" });
+
+        await act.Should().ThrowAsync<CosmosException>()
+            .Where(e => e.StatusCode == HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task Patch_FilterPredicate_MissingPropertyEqualsString_ThrowsPreconditionFailed()
+    {
+        var container = new InMemoryContainer("test", "/partitionKey");
+        // Document without linkedId property at all
+        await container.CreateItemStreamAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes(
+                """{"id":"1","partitionKey":"pk1","name":"test"}""")),
+            new PartitionKey("pk1"));
+
+        // undefined treated as null — null ≠ 'some-value'
+        var act = () => container.PatchItemAsync<JObject>(
+            "1", new PartitionKey("pk1"),
+            [PatchOperation.Set("/name", "updated")],
+            new PatchItemRequestOptions { FilterPredicate = "FROM c WHERE c.linkedId = 'some-value'" });
+
+        await act.Should().ThrowAsync<CosmosException>()
+            .Where(e => e.StatusCode == HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task Patch_FilterPredicate_ExplicitNullEqualsNull_Succeeds()
+    {
+        var container = new InMemoryContainer("test", "/partitionKey");
+        // Document WITH explicit null for linkedId
+        await container.CreateItemStreamAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes(
+                """{"id":"1","partitionKey":"pk1","linkedId":null,"name":"test"}""")),
+            new PartitionKey("pk1"));
+
+        var result = await container.PatchItemAsync<JObject>(
+            "1", new PartitionKey("pk1"),
+            [PatchOperation.Set("/linkedId", "new-value")],
+            new PatchItemRequestOptions { FilterPredicate = "FROM c WHERE c.linkedId = null" });
+
+        result.Resource["linkedId"]!.Value<string>().Should().Be("new-value");
+    }
+
+    [Fact]
+    public async Task Patch_FilterPredicate_MissingPropertyWithAndCondition_Succeeds()
+    {
+        var container = new InMemoryContainer("test", "/partitionKey");
+        // Document without linkedId but with name
+        await container.CreateItemStreamAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes(
+                """{"id":"1","partitionKey":"pk1","name":"test"}""")),
+            new PartitionKey("pk1"));
+
+        var result = await container.PatchItemAsync<JObject>(
+            "1", new PartitionKey("pk1"),
+            [PatchOperation.Set("/linkedId", "new-value")],
+            new PatchItemRequestOptions
+            {
+                FilterPredicate = "FROM c WHERE c.linkedId = null AND c.name = 'test'"
+            });
+
+        result.Resource["linkedId"]!.Value<string>().Should().Be("new-value");
+    }
+}
+
+
 // ── Category L: FakeCosmosHandler Patch Bugs ─────────────────────────────────
 
 public class FakeCosmosHandlerPatchBugTests

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/QueryPlanDeepDiveTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/QueryPlanDeepDiveTests.cs
@@ -207,26 +207,30 @@ public class QueryPlanDeepDiveTests : IDisposable
     }
 
     [Fact]
-    public async Task QueryPlan_SingleAggregateNoGroupByNoValue_PreservedInPlan()
+    public async Task QueryPlan_SingleAggregateNoGroupByNoValue_SuppressedForLinuxCompatibility()
     {
+        // Single-aggregate bypass: aggregates are suppressed so the SDK
+        // doesn't activate AggregateQueryPipelineStage on non-Windows platforms.
         var plan = await GetQueryPlanAsync("SELECT COUNT(1) FROM c");
         var info = plan["queryInfo"]!;
 
         var aggs = info["aggregates"]!.ToObject<string[]>()!;
-        aggs.Should().Contain("Count");
+        aggs.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task QueryPlan_SingleAggregateWithAlias_MappedCorrectly()
+    public async Task QueryPlan_SingleAggregateWithAlias_SuppressedForLinuxCompatibility()
     {
+        // Single-aggregate bypass: aggregates are suppressed so the SDK
+        // doesn't activate AggregateQueryPipelineStage on non-Windows platforms.
         var plan = await GetQueryPlanAsync("SELECT COUNT(1) AS cnt FROM c");
         var info = plan["queryInfo"]!;
 
         var aggs = info["aggregates"]!.ToObject<string[]>()!;
-        aggs.Should().Contain("Count");
+        aggs.Should().BeEmpty();
 
-        var aliasMap = info["groupByAliasToAggregateType"]!;
-        aliasMap["cnt"]!.ToString().Should().Be("Count");
+        var aliasMap = (JObject)info["groupByAliasToAggregateType"]!;
+        aliasMap.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/QueryPlanTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/QueryPlanTests.cs
@@ -154,23 +154,27 @@ public class QueryPlanTests : IDisposable
     }
 
     [Fact]
-    public async Task QueryPlan_CountAggregate_DetectsCount()
+    public async Task QueryPlan_CountAggregate_SuppressedForLinuxCompatibility()
     {
+        // Single-aggregate bypass: aggregates are suppressed so the SDK
+        // doesn't activate AggregateQueryPipelineStage on non-Windows platforms.
         var plan = await GetQueryPlanAsync("SELECT COUNT(1) FROM c");
         var info = plan["queryInfo"]!;
 
         var aggregates = (JArray)info["aggregates"]!;
-        aggregates.Should().Contain(t => t.ToString() == "Count");
+        aggregates.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task QueryPlan_SumAggregate_DetectsSum()
+    public async Task QueryPlan_SumAggregate_SuppressedForLinuxCompatibility()
     {
+        // Single-aggregate bypass: aggregates are suppressed so the SDK
+        // doesn't activate AggregateQueryPipelineStage on non-Windows platforms.
         var plan = await GetQueryPlanAsync("SELECT SUM(c.value) FROM c");
         var info = plan["queryInfo"]!;
 
         var aggregates = (JArray)info["aggregates"]!;
-        aggregates.Should().Contain(t => t.ToString() == "Sum");
+        aggregates.Should().BeEmpty();
     }
 
     [Fact]
@@ -426,23 +430,27 @@ public class QueryPlanTests : IDisposable
     }
 
     [Fact]
-    public async Task QueryPlan_CountWithoutAlias_StillDetectsAggregate()
+    public async Task QueryPlan_CountWithoutAlias_SuppressedForLinuxCompatibility()
     {
+        // Single-aggregate bypass: aggregates are suppressed so the SDK
+        // doesn't activate AggregateQueryPipelineStage on non-Windows platforms.
         var plan = await GetQueryPlanAsync("SELECT COUNT(1) FROM c");
         var info = plan["queryInfo"]!;
 
         var aggregates = (JArray)info["aggregates"]!;
-        aggregates.Should().Contain(t => t.ToString() == "Count");
+        aggregates.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task QueryPlan_AggregateFunctionCaseInsensitive_Detected()
+    public async Task QueryPlan_AggregateFunctionCaseInsensitive_SuppressedForLinuxCompatibility()
     {
+        // Single-aggregate bypass: aggregates are suppressed so the SDK
+        // doesn't activate AggregateQueryPipelineStage on non-Windows platforms.
         var plan = await GetQueryPlanAsync("SELECT count(1) AS cnt FROM c");
         var info = plan["queryInfo"]!;
 
         var aggregates = (JArray)info["aggregates"]!;
-        aggregates.Should().Contain(t => t.ToString() == "Count");
+        aggregates.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/QueryTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/QueryTests.cs
@@ -28462,16 +28462,16 @@ public class QueryDeepDiveV23_MathOpIntegerPreservationBugTests
     }
 
     [Fact]
-    public async Task Floor_DoubleInput_ReturnsFloat()
+    public async Task Floor_DoubleInput_ReturnsInteger()
     {
         await _container.CreateItemStreamAsync(
             new MemoryStream(Encoding.UTF8.GetBytes("""{"id":"1","partitionKey":"pk1","dblVal":5.7}""")),
             new PartitionKey("pk1"));
         var results = await RunQuery("SELECT VALUE FLOOR(c.dblVal) FROM c");
         results.Should().ContainSingle();
-        // FLOOR(5.7) = 5, but since input was double, result is double
-        results[0].Type.Should().Be(JTokenType.Float);
-        results[0].Value<double>().Should().Be(5.0);
+        // Ref: Cosmos DB normalizes all JSON numbers — FLOOR(5.7) = 5 (integer in JSON)
+        results[0].Type.Should().Be(JTokenType.Integer);
+        results[0].Value<long>().Should().Be(5);
     }
 
     [Fact]

--- a/tests/CosmosDB.InMemoryEmulator.Tests.Unit/StoredProcedureTests.cs
+++ b/tests/CosmosDB.InMemoryEmulator.Tests.Unit/StoredProcedureTests.cs
@@ -1161,7 +1161,7 @@ public class UdfGapTests
     [Fact]
     public async Task Udf_RegisterAndUseInQuery()
     {
-        _container.RegisterUdf("double", args => ((double)args[0]) * 2);
+        _container.RegisterUdf("double", args => Convert.ToDouble(args[0]) * 2);
 
         await _container.CreateItemAsync(
             new UdfDocument { Id = "1", PartitionKey = "pk1", Value = 21 },
@@ -1183,7 +1183,7 @@ public class UdfGapTests
     [Fact]
     public async Task Udf_MultipleArgs()
     {
-        _container.RegisterUdf("add", args => (double)args[0] + (double)args[1]);
+        _container.RegisterUdf("add", args => Convert.ToDouble(args[0]) + Convert.ToDouble(args[1]));
 
         await _container.CreateItemAsync(
             new UdfDocument { Id = "1", PartitionKey = "pk1", X = 10, Y = 20 },
@@ -1227,7 +1227,7 @@ public class UdfGapTests
     [Fact]
     public async Task DeregisterUdf_RemovesHandler()
     {
-        _container.RegisterUdf("removable", args => (double)args[0] * 10);
+        _container.RegisterUdf("removable", args => Convert.ToDouble(args[0]) * 10);
 
         await _container.CreateItemAsync(
             new UdfDocument { Id = "1", PartitionKey = "pk1", Value = 5 },
@@ -1315,7 +1315,7 @@ public class UdfGapTests
     [Fact]
     public async Task Udf_InWhereClause_FiltersCorrectly()
     {
-        _container.RegisterUdf("isEven", args => ((double)args[0]) % 2 == 0);
+        _container.RegisterUdf("isEven", args => Convert.ToDouble(args[0]) % 2 == 0);
 
         await _container.CreateItemAsync(
             new UdfDocument { Id = "1", PartitionKey = "pk1", Value = 2 }, new PartitionKey("pk1"));

--- a/tests/EmulatorWarmup/Program.cs
+++ b/tests/EmulatorWarmup/Program.cs
@@ -239,6 +239,10 @@ internal static class Program
         // 404/1013 — "Collection is not yet available for read".
         CosmosException ce when ce.StatusCode == HttpStatusCode.NotFound
                               && ce.SubStatusCode == 1013 => true,
+        // 404/0 — Windows emulator intermediate startup state: HTTP server is
+        // reachable but internal metadata services haven't fully materialised.
+        CosmosException ce when ce.StatusCode == HttpStatusCode.NotFound
+                              && ce.SubStatusCode == 0 => true,
         CosmosException ce => ce.StatusCode is
             HttpStatusCode.ServiceUnavailable or
             HttpStatusCode.InternalServerError or

--- a/tests/emulator-containers.json
+++ b/tests/emulator-containers.json
@@ -7,6 +7,7 @@
     { "name": "pknone-test", "partitionKeyPath": "/partitionKey" },
     { "name": "num-pk-test", "partitionKeyPath": "/numericPk" },
     { "name": "bool-pk-test", "partitionKeyPath": "/boolPk" },
+    { "name": "test-decimal-scale", "partitionKeyPath": "/partitionKey" },
     { "name": "test-batch", "partitionKeyPath": "/partitionKey" },
     { "name": "test-bulk", "partitionKeyPath": "/partitionKey" },
     { "name": "test-pk", "partitionKeyPath": "/partitionKey" },


### PR DESCRIPTION
## Summary

This PR combines six bug-fix PRs into a single release (v4.0.21):

### PR #65 — Fix COUNT(expr) with nested ternary expressions (#64)
- `ExprToString` now parenthesises ternary/coalesce sub-expressions when inside higher-precedence operators
- Fixes miscounting documents in `COUNT()` when nested ternary expressions are involved
- 10 integration tests added

### PR #66 — Remove EmulatorFlaky trait, use adaptive concurrency
- Replaces blanket `EmulatorFlaky` exclusions with adaptive concurrency (50 parallel for in-memory, 10 for emulator)
- All tests now run against all targets with no exclusions beyond `InMemoryOnly`

### PR #68 — Fix string literal aliases on Linux + cross-platform CI (#67)
- `ProjectAggregateFields` now evaluates literal/expression fields instead of treating them as property paths
- `DefaultQueryPlanStrategy` bypasses SDK aggregate pipeline when literals appear alongside aggregates
- Integration tests now run on **both** Linux and Windows in CI
- 5 integration tests added

### PR #71 — Fix FilterPredicate missing properties (#70)
- Treats missing properties as `null` in `FilterPredicate` instead of throwing
- Fixes patch operations with filter predicates referencing non-existent properties
- Integration tests added

### PR #73 — Return documents in insertion order for queries without ORDER BY (#72)
- Added insertion-order tracking to `InMemoryContainer` that maintains document position across create, replace, upsert, and delete operations
- Queries without `ORDER BY` now return documents in insertion order, matching real Cosmos DB behavior
- Integration tests added

### PR #78 — Fix decimal scale preservation and SUM aggregate cross-platform (#75)
- Custom `CosmosJsonWriter` normalizes numeric representations during `ParseJson` to match real Cosmos DB (whole numbers as integers, fractional values with minimal representation)
- Aggregate assignment points normalize whole-number doubles to longs before serialization, fixing SUM inconsistency across platforms
- Query plan strategy now suppresses all aggregate info on non-Windows platforms, preventing SDK pipeline conflicts
- Fixed double-to-long overflow at `long.MaxValue` boundary
- 23 integration tests added

## Version

Bumped to **4.0.21**

## Supersedes

Closes #64, Closes #67, Closes #70, Closes #72, Closes #75

Once merged, PRs #65, #66, #68, #71, #73, and #78 should be closed without merging.